### PR TITLE
Remove Backroll prefixes

### DIFF
--- a/backroll/src/backend/mod.rs
+++ b/backroll/src/backend/mod.rs
@@ -1,4 +1,4 @@
-use super::{BackrollError, BackrollPlayer, BackrollPlayerHandle, BackrollResult};
+use super::{BackrollError, Player, PlayerHandle, BackrollResult};
 
 mod p2p;
 mod sync_test;

--- a/backroll/src/backend/mod.rs
+++ b/backroll/src/backend/mod.rs
@@ -1,4 +1,4 @@
-use super::{BackrollError, Player, PlayerHandle, BackrollResult};
+use super::{BackrollError, BackrollResult, Player, PlayerHandle};
 
 mod p2p;
 mod sync_test;

--- a/backroll/src/backend/p2p.rs
+++ b/backroll/src/backend/p2p.rs
@@ -1,8 +1,8 @@
-use super::{BackrollError, Player, PlayerHandle, BackrollResult};
+use super::{BackrollError, BackrollResult, Player, PlayerHandle};
 use crate::{
     input::FrameInput,
     is_null,
-    protocol::{Peer, PeerConfig, ConnectionStatus, Event as ProtocolEvent},
+    protocol::{ConnectionStatus, Event as ProtocolEvent, Peer, PeerConfig},
     sync::{self, Sync},
     transport::Peer as TransportPeer,
     Config, Event, Frame, NetworkStats, SessionCallbacks, TaskPool,
@@ -139,6 +139,15 @@ where
     disconnect_timeout: Duration,
     disconnect_notify_start: Duration,
     marker_: std::marker::PhantomData<T>,
+}
+
+impl<T> Default for P2PSessionBuilder<T>
+where
+    T: Config,
+{
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<T> P2PSessionBuilder<T>
@@ -528,7 +537,7 @@ impl<T: Config> P2PSessionRef<T> {
             }
             info!("min_frame = {}.", min_frame);
         }
-        return min_frame;
+        min_frame
     }
 
     fn is_synchronized(&self) -> bool {
@@ -668,11 +677,7 @@ impl<T: Config> P2PSession<T> {
     ///
     /// [BackrollError]: crate::BackrollError
     /// [advance_frame]: self::P2PSession::advance_frame
-    pub fn add_local_input(
-        &self,
-        player: PlayerHandle,
-        input: T::Input,
-    ) -> BackrollResult<()> {
+    pub fn add_local_input(&self, player: PlayerHandle, input: T::Input) -> BackrollResult<()> {
         let mut session_ref = self.0.write();
         if session_ref.sync.in_rollback() {
             return Err(BackrollError::InRollback);
@@ -773,11 +778,7 @@ impl<T: Config> P2PSession<T> {
     /// # Errors
     /// Returns [BackrollError::InvalidPlayer] if the provided player handle does not point a vali
     /// player.
-    pub fn set_frame_delay(
-        &self,
-        player: PlayerHandle,
-        delay: Frame,
-    ) -> BackrollResult<()> {
+    pub fn set_frame_delay(&self, player: PlayerHandle, delay: Frame) -> BackrollResult<()> {
         let mut session_ref = self.0.write();
         let queue = session_ref.player_handle_to_queue(player)?;
         session_ref.sync.set_frame_delay(queue, delay);

--- a/backroll/src/backend/p2p.rs
+++ b/backroll/src/backend/p2p.rs
@@ -1,11 +1,11 @@
-use super::{BackrollError, BackrollPlayer, BackrollPlayerHandle, BackrollResult};
+use super::{BackrollError, Player, PlayerHandle, BackrollResult};
 use crate::{
     input::FrameInput,
     is_null,
-    protocol::{BackrollPeer, BackrollPeerConfig, ConnectionStatus, Event},
-    sync::{self, BackrollSync},
-    transport::Peer,
-    BackrollConfig, BackrollEvent, Frame, NetworkStats, SessionCallbacks, TaskPool,
+    protocol::{Peer, PeerConfig, ConnectionStatus, Event as ProtocolEvent},
+    sync::{self, Sync},
+    transport::Peer as TransportPeer,
+    Config, Event, Frame, NetworkStats, SessionCallbacks, TaskPool,
 };
 use async_channel::TryRecvError;
 use parking_lot::RwLock;
@@ -17,22 +17,22 @@ const RECOMMENDATION_INTERVAL: Frame = 240;
 const DEFAULT_DISCONNECT_TIMEOUT: Duration = Duration::from_millis(5000);
 const DEFAULT_DISCONNECT_NOTIFY_START: Duration = Duration::from_millis(750);
 
-enum Player<T>
+enum PlayerType<T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
     Local,
     Remote {
-        peer: BackrollPeer<T>,
-        rx: async_channel::Receiver<Event<T::Input>>,
+        peer: Peer<T>,
+        rx: async_channel::Receiver<ProtocolEvent<T::Input>>,
     },
     Spectator {
-        peer: BackrollPeer<T>,
-        rx: async_channel::Receiver<Event<T::Input>>,
+        peer: Peer<T>,
+        rx: async_channel::Receiver<ProtocolEvent<T::Input>>,
     },
 }
 
-impl<T: BackrollConfig> Clone for Player<T> {
+impl<T: Config> Clone for PlayerType<T> {
     fn clone(&self) -> Self {
         match self {
             Self::Local => Self::Local,
@@ -48,45 +48,45 @@ impl<T: BackrollConfig> Clone for Player<T> {
     }
 }
 
-impl<T: BackrollConfig> Player<T> {
+impl<T: Config> PlayerType<T> {
     pub fn new(
         queue: usize,
-        player: &BackrollPlayer,
+        player: &Player,
         builder: &P2PSessionBuilder<T>,
         connect: Arc<[RwLock<ConnectionStatus>]>,
         task_pool: TaskPool,
     ) -> Self {
         match player {
-            BackrollPlayer::Local => Self::Local,
-            BackrollPlayer::Remote(peer) => {
+            Player::Local => Self::Local,
+            Player::Remote(peer) => {
                 let (peer, rx) = Self::make_peer(queue, peer, builder, connect, task_pool);
-                Player::<T>::Remote { peer, rx }
+                PlayerType::<T>::Remote { peer, rx }
             }
-            BackrollPlayer::Spectator(peer) => {
+            Player::Spectator(peer) => {
                 let (peer, rx) = Self::make_peer(queue, peer, builder, connect, task_pool);
-                Player::<T>::Spectator { peer, rx }
+                PlayerType::<T>::Spectator { peer, rx }
             }
         }
     }
 
     fn make_peer(
         queue: usize,
-        peer: &Peer,
+        peer: &TransportPeer,
         builder: &P2PSessionBuilder<T>,
         connect: Arc<[RwLock<ConnectionStatus>]>,
         pool: TaskPool,
-    ) -> (BackrollPeer<T>, async_channel::Receiver<Event<T::Input>>) {
-        let config = BackrollPeerConfig {
+    ) -> (Peer<T>, async_channel::Receiver<ProtocolEvent<T::Input>>) {
+        let config = PeerConfig {
             peer: peer.clone(),
             disconnect_timeout: builder.disconnect_timeout,
             disconnect_notify_start: builder.disconnect_notify_start,
             task_pool: pool,
         };
 
-        BackrollPeer::<T>::new(queue, config, connect)
+        Peer::<T>::new(queue, config, connect)
     }
 
-    pub fn peer(&self) -> Option<&BackrollPeer<T>> {
+    pub fn peer(&self) -> Option<&Peer<T>> {
         match self {
             Self::Local => None,
             Self::Remote { ref peer, .. } => Some(peer),
@@ -133,9 +133,9 @@ impl<T: BackrollConfig> Player<T> {
 
 pub struct P2PSessionBuilder<T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
-    players: Vec<BackrollPlayer>,
+    players: Vec<Player>,
     disconnect_timeout: Duration,
     disconnect_notify_start: Duration,
     marker_: std::marker::PhantomData<T>,
@@ -143,7 +143,7 @@ where
 
 impl<T> P2PSessionBuilder<T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
     /// Creates a new builder. Identical to [P2PSession::build].
     ///
@@ -174,10 +174,10 @@ where
     }
 
     /// Adds a player to the session and returns the corresponding handle.
-    pub fn add_player(&mut self, player: BackrollPlayer) -> BackrollPlayerHandle {
+    pub fn add_player(&mut self, player: Player) -> PlayerHandle {
         let id = self.players.len();
         self.players.push(player);
-        BackrollPlayerHandle(id)
+        PlayerHandle(id)
     }
 
     /// Constructs and starts the P2PSession. Consumes the builder.
@@ -194,10 +194,10 @@ where
 
 struct P2PSessionRef<T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
-    sync: BackrollSync<T>,
-    players: Vec<Player<T>>,
+    sync: Sync<T>,
+    players: Vec<PlayerType<T>>,
 
     synchronizing: bool,
     next_recommended_sleep: Frame,
@@ -206,8 +206,8 @@ where
     local_connect_status: Arc<[RwLock<ConnectionStatus>]>,
 }
 
-impl<T: BackrollConfig> P2PSessionRef<T> {
-    fn players(&self) -> impl Iterator<Item = &BackrollPeer<T>> {
+impl<T: Config> P2PSessionRef<T> {
+    fn players(&self) -> impl Iterator<Item = &Peer<T>> {
         self.players
             .iter()
             .filter(|player| player.is_remote_player())
@@ -215,7 +215,7 @@ impl<T: BackrollConfig> P2PSessionRef<T> {
             .flatten()
     }
 
-    fn spectators(&self) -> impl Iterator<Item = &BackrollPeer<T>> {
+    fn spectators(&self) -> impl Iterator<Item = &Peer<T>> {
         self.players
             .iter()
             .filter(|player| player.is_spectator())
@@ -223,7 +223,7 @@ impl<T: BackrollConfig> P2PSessionRef<T> {
             .flatten()
     }
 
-    fn player_handle_to_queue(&self, player: BackrollPlayerHandle) -> BackrollResult<usize> {
+    fn player_handle_to_queue(&self, player: PlayerHandle) -> BackrollResult<usize> {
         let offset = player.0;
         if offset >= self.sync.player_count() {
             return Err(BackrollError::InvalidPlayer(player));
@@ -233,7 +233,7 @@ impl<T: BackrollConfig> P2PSessionRef<T> {
 
     fn check_initial_sync(&mut self, callbacks: &mut impl SessionCallbacks<T>) {
         if self.synchronizing && self.is_synchronized() {
-            callbacks.handle_event(BackrollEvent::Running);
+            callbacks.handle_event(Event::Running);
             self.synchronizing = false;
         }
     }
@@ -241,7 +241,7 @@ impl<T: BackrollConfig> P2PSessionRef<T> {
     fn disconnect_player(
         &mut self,
         callbacks: &mut impl SessionCallbacks<T>,
-        player: BackrollPlayerHandle,
+        player: PlayerHandle,
     ) -> BackrollResult<()> {
         let queue = self.player_handle_to_queue(player)?;
         if self.local_connect_status[queue].read().disconnected {
@@ -301,14 +301,14 @@ impl<T: BackrollConfig> P2PSessionRef<T> {
             info!("Finished adjusting simulation.");
         }
 
-        callbacks.handle_event(BackrollEvent::Disconnected(BackrollPlayerHandle(queue)));
+        callbacks.handle_event(Event::Disconnected(PlayerHandle(queue)));
 
         self.check_initial_sync(callbacks);
     }
 
     fn flush_events(&mut self, callbacks: &mut impl SessionCallbacks<T>) {
         for (queue, player) in self.players.clone().iter().enumerate() {
-            if let Player::<T>::Remote { rx, .. } = player {
+            if let PlayerType::<T>::Remote { rx, .. } = player {
                 self.flush_peer_events(callbacks, queue, rx.clone());
             }
         }
@@ -318,14 +318,14 @@ impl<T: BackrollConfig> P2PSessionRef<T> {
         &mut self,
         callbacks: &mut impl SessionCallbacks<T>,
         queue: usize,
-        rx: async_channel::Receiver<Event<T::Input>>,
+        rx: async_channel::Receiver<ProtocolEvent<T::Input>>,
     ) {
         loop {
             match rx.try_recv() {
                 Ok(evt) => self.handle_event(callbacks, queue, evt),
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Closed) => {
-                    self.disconnect_player(callbacks, BackrollPlayerHandle(queue))
+                    self.disconnect_player(callbacks, PlayerHandle(queue))
                         .expect("Disconnecting should not error on closing connection");
                     break;
                 }
@@ -337,21 +337,21 @@ impl<T: BackrollConfig> P2PSessionRef<T> {
         &mut self,
         callbacks: &mut impl SessionCallbacks<T>,
         queue: usize,
-        evt: Event<T::Input>,
+        evt: ProtocolEvent<T::Input>,
     ) {
-        let player = BackrollPlayerHandle(queue);
+        let player = PlayerHandle(queue);
         match evt {
-            Event::<T::Input>::Connected => {
-                callbacks.handle_event(BackrollEvent::Connected(BackrollPlayerHandle(queue)));
+            ProtocolEvent::<T::Input>::Connected => {
+                callbacks.handle_event(Event::Connected(PlayerHandle(queue)));
             }
-            Event::<T::Input>::Synchronizing { total, count } => {
-                callbacks.handle_event(BackrollEvent::Synchronizing {
+            ProtocolEvent::<T::Input>::Synchronizing { total, count } => {
+                callbacks.handle_event(Event::Synchronizing {
                     player,
                     total,
                     count,
                 });
             }
-            Event::<T::Input>::Inputs(inputs) => {
+            ProtocolEvent::<T::Input>::Inputs(inputs) => {
                 let mut status = self.local_connect_status[queue].write();
                 if status.disconnected {
                     return;
@@ -375,18 +375,18 @@ impl<T: BackrollConfig> P2PSessionRef<T> {
                     status.last_frame = new_remote_frame;
                 }
             }
-            Event::<T::Input>::Synchronized => {
-                callbacks.handle_event(BackrollEvent::Synchronized(player));
+            ProtocolEvent::<T::Input>::Synchronized => {
+                callbacks.handle_event(Event::Synchronized(player));
                 self.check_initial_sync(callbacks);
             }
-            Event::<T::Input>::NetworkInterrupted { disconnect_timeout } => {
-                callbacks.handle_event(BackrollEvent::ConnectionInterrupted {
+            ProtocolEvent::<T::Input>::NetworkInterrupted { disconnect_timeout } => {
+                callbacks.handle_event(Event::ConnectionInterrupted {
                     player,
                     disconnect_timeout,
                 });
             }
-            Event::<T::Input>::NetworkResumed => {
-                callbacks.handle_event(BackrollEvent::Synchronized(player));
+            ProtocolEvent::<T::Input>::NetworkResumed => {
+                callbacks.handle_event(Event::Synchronized(player));
             }
         }
     }
@@ -446,7 +446,7 @@ impl<T: BackrollConfig> P2PSessionRef<T> {
                 .map(|player| player.recommend_frame_delay())
                 .max();
             if let Some(interval) = interval {
-                callbacks.handle_event(BackrollEvent::TimeSync {
+                callbacks.handle_event(Event::TimeSync {
                     frames_ahead: interval as u8,
                 });
                 self.next_recommended_sleep = current_frame + RECOMMENDATION_INTERVAL;
@@ -548,15 +548,15 @@ impl<T: BackrollConfig> P2PSessionRef<T> {
 
 pub struct P2PSession<T>(Arc<RwLock<P2PSessionRef<T>>>)
 where
-    T: BackrollConfig;
+    T: Config;
 
-impl<T: BackrollConfig> Clone for P2PSession<T> {
+impl<T: Config> Clone for P2PSession<T> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 }
 
-impl<T: BackrollConfig> P2PSession<T> {
+impl<T: Config> P2PSession<T> {
     pub fn build() -> P2PSessionBuilder<T> {
         P2PSessionBuilder::new()
     }
@@ -577,12 +577,12 @@ impl<T: BackrollConfig> P2PSession<T> {
             (0..player_count).map(|_| Default::default()).collect();
         let connect_status: Arc<[RwLock<ConnectionStatus>]> = connect_status.into();
 
-        let players: Vec<Player<T>> = builder
+        let players: Vec<PlayerType<T>> = builder
             .players
             .iter()
             .enumerate()
             .map(|(i, player)| {
-                Player::<T>::new(
+                PlayerType::<T>::new(
                     i,
                     player,
                     &builder,
@@ -593,8 +593,8 @@ impl<T: BackrollConfig> P2PSession<T> {
             .collect();
 
         let synchronizing = players.iter().any(|player| !player.is_local());
-        let config = sync::Config { player_count };
-        let sync = BackrollSync::<T>::new(config, connect_status.clone());
+        let config = sync::PlayerConfig { player_count };
+        let sync = Sync::<T>::new(config, connect_status.clone());
         Ok(Self(Arc::new(RwLock::new(P2PSessionRef::<T> {
             sync,
             players,
@@ -621,25 +621,25 @@ impl<T: BackrollConfig> P2PSession<T> {
         self.0.read().sync.frame_count()
     }
 
-    pub fn local_players(&self) -> Vec<BackrollPlayerHandle> {
+    pub fn local_players(&self) -> Vec<PlayerHandle> {
         self.0
             .read()
             .players
             .iter()
             .enumerate()
             .filter(|(_, player)| player.is_local())
-            .map(|(i, _)| BackrollPlayerHandle(i))
+            .map(|(i, _)| PlayerHandle(i))
             .collect()
     }
 
-    pub fn remote_players(&self) -> Vec<BackrollPlayerHandle> {
+    pub fn remote_players(&self) -> Vec<PlayerHandle> {
         self.0
             .read()
             .players
             .iter()
             .enumerate()
             .filter(|(_, player)| player.is_remote_player())
-            .map(|(i, _)| BackrollPlayerHandle(i))
+            .map(|(i, _)| PlayerHandle(i))
             .collect()
     }
 
@@ -670,7 +670,7 @@ impl<T: BackrollConfig> P2PSession<T> {
     /// [advance_frame]: self::P2PSession::advance_frame
     pub fn add_local_input(
         &self,
-        player: BackrollPlayerHandle,
+        player: PlayerHandle,
         input: T::Input,
     ) -> BackrollResult<()> {
         let mut session_ref = self.0.write();
@@ -722,7 +722,7 @@ impl<T: BackrollConfig> P2PSession<T> {
     pub fn disconnect_player(
         &self,
         callbacks: &mut impl SessionCallbacks<T>,
-        player: BackrollPlayerHandle,
+        player: PlayerHandle,
     ) -> BackrollResult<()> {
         let mut session_ref = self.0.write();
         let queue = session_ref.player_handle_to_queue(player)?;
@@ -760,7 +760,7 @@ impl<T: BackrollConfig> P2PSession<T> {
     /// # Errors
     /// Returns [BackrollError::InvalidPlayer] if the provided player handle does not point a vali
     /// player.
-    pub fn get_network_stats(&self, player: BackrollPlayerHandle) -> BackrollResult<NetworkStats> {
+    pub fn get_network_stats(&self, player: PlayerHandle) -> BackrollResult<NetworkStats> {
         let session_ref = self.0.read();
         let queue = session_ref.player_handle_to_queue(player)?;
         Ok(session_ref.players[queue]
@@ -775,7 +775,7 @@ impl<T: BackrollConfig> P2PSession<T> {
     /// player.
     pub fn set_frame_delay(
         &self,
-        player: BackrollPlayerHandle,
+        player: PlayerHandle,
         delay: Frame,
     ) -> BackrollResult<()> {
         let mut session_ref = self.0.write();

--- a/backroll/src/input.rs
+++ b/backroll/src/input.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BackrollConfig, BackrollError, BackrollPlayerHandle, Frame, MAX_PLAYERS_PER_MATCH,
+    Config, BackrollError, PlayerHandle, Frame, MAX_PLAYERS_PER_MATCH,
     MAX_ROLLBACK_FRAMES,
 };
 use std::convert::TryFrom;
@@ -57,7 +57,7 @@ impl<T: bytemuck::Zeroable> GameInput<T> {
     /// if the provided player handle does not correspond to a valid player.
     ///
     /// [InvalidPlayer]: crate::BackrollError::InvalidPlayer
-    pub fn get(&self, player: BackrollPlayerHandle) -> Result<&T, BackrollError> {
+    pub fn get(&self, player: PlayerHandle) -> Result<&T, BackrollError> {
         if player.0 >= MAX_PLAYERS_PER_MATCH {
             return Err(BackrollError::InvalidPlayer(player));
         }
@@ -68,7 +68,7 @@ impl<T: bytemuck::Zeroable> GameInput<T> {
     /// if the provided player handle does not correspond to a valid player.
     ///
     /// [InvalidPlayer]: crate::BackrollError::InvalidPlayer
-    pub fn is_disconnected(&self, player: BackrollPlayerHandle) -> Result<bool, BackrollError> {
+    pub fn is_disconnected(&self, player: PlayerHandle) -> Result<bool, BackrollError> {
         if player.0 >= MAX_PLAYERS_PER_MATCH {
             return Err(BackrollError::InvalidPlayer(player));
         }
@@ -100,7 +100,7 @@ impl<T> FetchedInput<T> {
 
 pub struct InputQueue<T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
     head: usize,
     tail: usize,
@@ -118,7 +118,7 @@ where
     prediction: FrameInput<T::Input>,
 }
 
-impl<T: BackrollConfig> InputQueue<T> {
+impl<T: Config> InputQueue<T> {
     #[allow(clippy::uninit_assumed_init)]
     pub fn new() -> Self {
         // This is necessary as Default is not defined on arrays of more

--- a/backroll/src/input.rs
+++ b/backroll/src/input.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Config, BackrollError, PlayerHandle, Frame, MAX_PLAYERS_PER_MATCH,
-    MAX_ROLLBACK_FRAMES,
+    BackrollError, Config, Frame, PlayerHandle, MAX_PLAYERS_PER_MATCH, MAX_ROLLBACK_FRAMES,
 };
 use std::convert::TryFrom;
 use tracing::info;

--- a/backroll/src/lib.rs
+++ b/backroll/src/lib.rs
@@ -79,7 +79,7 @@ where
 
     ///  Notification that something has happened. See the `[BackcrollEvent]`
     /// struct for more information.
-    fn handle_event(&mut self, event: BackrollEvent);
+    fn handle_event(&mut self, event: Event);
 }
 
 #[derive(Clone, Debug, Error)]

--- a/backroll/src/lib.rs
+++ b/backroll/src/lib.rs
@@ -28,9 +28,9 @@ fn is_null(frame: Frame) -> bool {
 
 /// A handle for a player in a Backroll session.
 #[derive(Copy, Clone, Debug)]
-pub struct BackrollPlayerHandle(pub usize);
+pub struct PlayerHandle(pub usize);
 
-pub enum BackrollPlayer {
+pub enum Player {
     /// The local player. Backroll currently only supports one local player per machine.
     Local,
     /// A non-participating peer that recieves inputs but does not send any.
@@ -39,13 +39,13 @@ pub enum BackrollPlayer {
     Remote(transport::Peer),
 }
 
-impl BackrollPlayer {
+impl Player {
     pub(crate) fn is_local(&self) -> bool {
         matches!(self, Self::Local)
     }
 }
 
-pub trait BackrollConfig: 'static {
+pub trait Config: 'static {
     type Input: Eq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync;
 
     /// The save state type for the session. This type must be safe to send across
@@ -59,7 +59,7 @@ pub trait BackrollConfig: 'static {
 
 pub trait SessionCallbacks<T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
     /// The client should copy the entire contents of the current game state into a
     ///  new state struct and return it.
@@ -93,9 +93,9 @@ pub enum BackrollError {
     #[error("The simulation has reached the prediction barrier.")]
     ReachedPredictionBarrier,
     #[error("Invalid player handle: {:?}", .0)]
-    InvalidPlayer(BackrollPlayerHandle),
+    InvalidPlayer(PlayerHandle),
     #[error("Player already disconnected: {:?}", .0)]
-    PlayerDisconnected(BackrollPlayerHandle),
+    PlayerDisconnected(PlayerHandle),
 }
 
 pub type BackrollResult<T> = Result<T, BackrollError>;
@@ -112,32 +112,32 @@ pub struct NetworkStats {
 }
 
 #[derive(Clone, Debug)]
-pub enum BackrollEvent {
+pub enum Event {
     /// A initial response packet from the remote player has been recieved.
-    Connected(BackrollPlayerHandle),
+    Connected(PlayerHandle),
     /// A response from a remote player has been recieved during the initial
     /// synchronization handshake.
     Synchronizing {
-        player: BackrollPlayerHandle,
+        player: PlayerHandle,
         count: u8,
         total: u8,
     },
     /// The initial synchronization handshake has been completed. The connection
     /// is considered live now.
-    Synchronized(BackrollPlayerHandle),
+    Synchronized(PlayerHandle),
     /// All remote peers are now synchronized, the session is can now start
     /// running.
     Running,
     /// The connection with a remote player has been disconnected.
-    Disconnected(BackrollPlayerHandle),
+    Disconnected(PlayerHandle),
     /// The local client is several frames ahead of all other peers. Might need
     /// to stall a few frames to allow others to catch up.
     TimeSync { frames_ahead: u8 },
     /// The connection with a remote player has been temporarily interrupted.
     ConnectionInterrupted {
-        player: BackrollPlayerHandle,
+        player: PlayerHandle,
         disconnect_timeout: Duration,
     },
     /// The connection with a remote player has been resumed after being interrupted.
-    ConnectionResumed(BackrollPlayerHandle),
+    ConnectionResumed(PlayerHandle),
 }

--- a/backroll/src/protocol/compression.rs
+++ b/backroll/src/protocol/compression.rs
@@ -25,7 +25,7 @@ fn delta_encode<'a, T: bytemuck::Pod>(
     base: &'a T,
     data: impl Iterator<Item = &'a T>,
 ) -> Result<Vec<u8>, EncodeError> {
-    let mut base = base.clone();
+    let mut base = *base;
     let bits = bytemuck::bytes_of_mut(&mut base);
     let (lower, upper) = data.size_hint();
     let capacity = std::cmp::min(MAX_BUFFER_SIZE, upper.unwrap_or(lower) * bits.len());
@@ -79,7 +79,7 @@ pub fn decode<T: Pod>(base: &T, data: impl AsRef<[u8]>) -> Result<Vec<T>, Decode
         for (local_idx, byte) in bits.iter_mut().enumerate() {
             *byte ^= delta[idx * stride + local_idx];
         }
-        output.push(bytemuck::try_from_bytes::<T>(&bits)?.clone())
+        output.push(*bytemuck::try_from_bytes::<T>(&bits)?)
     }
 
     Ok(output)

--- a/backroll/src/protocol/message.rs
+++ b/backroll/src/protocol/message.rs
@@ -23,10 +23,7 @@ pub(super) enum MessageData {
 
 impl MessageData {
     pub fn is_sync_message(&self) -> bool {
-        match self {
-            Self::SyncRequest(_) | Self::SyncReply(_) => true,
-            _ => false,
-        }
+        matches!(self, Self::SyncRequest(_) | Self::SyncReply(_))
     }
 }
 

--- a/backroll/src/protocol/mod.rs
+++ b/backroll/src/protocol/mod.rs
@@ -83,27 +83,15 @@ impl PeerState {
     }
 
     pub fn is_running(&self) -> bool {
-        match self {
-            Self::Running { .. } => true,
-            Self::Interrupted { .. } => true,
-            _ => false,
-        }
+        matches!(self, Self::Running { .. } | Self::Interrupted { .. })
     }
 
     pub fn is_disconnected(&self) -> bool {
-        if let Self::Disconnected = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::Disconnected)
     }
 
     pub fn is_interrupted(&self) -> bool {
-        if let Self::Interrupted { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::Interrupted { .. })
     }
 
     pub fn start_syncing(&mut self, round_trips: u8) {
@@ -685,10 +673,10 @@ impl<T: Config> Peer<T> {
                 }
                 Ok(())
             }
-            PeerState::Running { remote_magic } if magic == remote_magic => return Ok(()),
+            PeerState::Running { remote_magic } if magic == remote_magic => Ok(()),
             _ => {
                 info!("Ignoring SyncReply while not syncing.");
-                return Err(PeerError::InvalidMessage);
+                Err(PeerError::InvalidMessage)
             }
         }
     }

--- a/backroll/src/protocol/mod.rs
+++ b/backroll/src/protocol/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     Config, Frame, NetworkStats, TaskPool,
 };
 use async_channel::TrySendError;
-use backroll_transport::Peer;
+use backroll_transport::Peer as TransportPeer;
 use bincode::config::Options;
 use futures::FutureExt;
 use futures_timer::Delay;
@@ -155,7 +155,7 @@ struct PeerStats {
 
 #[derive(Clone)]
 pub(crate) struct PeerConfig {
-    pub peer: Peer,
+    pub peer: TransportPeer,
     pub disconnect_timeout: Duration,
     pub disconnect_notify_start: Duration,
     pub task_pool: TaskPool,

--- a/backroll/src/protocol/mod.rs
+++ b/backroll/src/protocol/mod.rs
@@ -3,7 +3,7 @@ use self::message::*;
 use crate::{
     input::FrameInput,
     time_sync::{TimeSync, UnixMillis},
-    BackrollConfig, Frame, NetworkStats, TaskPool,
+    Config, Frame, NetworkStats, TaskPool,
 };
 use async_channel::TrySendError;
 use backroll_transport::Peer;
@@ -154,19 +154,19 @@ struct PeerStats {
 }
 
 #[derive(Clone)]
-pub(crate) struct BackrollPeerConfig {
+pub(crate) struct PeerConfig {
     pub peer: Peer,
     pub disconnect_timeout: Duration,
     pub disconnect_notify_start: Duration,
     pub task_pool: TaskPool,
 }
 
-pub(crate) struct BackrollPeer<T>
+pub(crate) struct Peer<T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
     queue: usize,
-    config: BackrollPeerConfig,
+    config: PeerConfig,
     timesync: TimeSync<T::Input>,
     state: Arc<RwLock<PeerState>>,
 
@@ -182,7 +182,7 @@ where
     events: async_channel::Sender<Event<T::Input>>,
 }
 
-impl<T: BackrollConfig> Clone for BackrollPeer<T> {
+impl<T: Config> Clone for Peer<T> {
     fn clone(&self) -> Self {
         Self {
             queue: self.queue,
@@ -204,10 +204,10 @@ impl<T: BackrollConfig> Clone for BackrollPeer<T> {
     }
 }
 
-impl<T: BackrollConfig> BackrollPeer<T> {
+impl<T: Config> Peer<T> {
     pub fn new(
         queue: usize,
-        config: BackrollPeerConfig,
+        config: PeerConfig,
         local_connect_status: Arc<[RwLock<ConnectionStatus>]>,
     ) -> (Self, async_channel::Receiver<Event<T::Input>>) {
         let (deserialize_send, message_in) = async_channel::unbounded::<Message>();

--- a/backroll/src/sync.rs
+++ b/backroll/src/sync.rs
@@ -290,7 +290,7 @@ impl<T: Config> Sync<T> {
         status.disconnected && status.last_frame < self.frame_count()
     }
 
-    fn create_queues(config: &Config) -> Vec<InputQueue<T>> {
+    fn create_queues(config: &PlayerConfig) -> Vec<InputQueue<T>> {
         (0..config.player_count)
             .map(|_| InputQueue::new())
             .collect()

--- a/backroll/src/sync.rs
+++ b/backroll/src/sync.rs
@@ -1,7 +1,7 @@
 use crate::{
     input::{FrameInput, GameInput, InputQueue},
     protocol::ConnectionStatus,
-    Config, BackrollError, BackrollResult, Frame, SessionCallbacks, NULL_FRAME,
+    BackrollError, BackrollResult, Config, Frame, SessionCallbacks, NULL_FRAME,
 };
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -86,7 +86,10 @@ where
 }
 
 impl<T: Config> Sync<T> {
-    pub fn new(config: PlayerConfig, local_connect_status: Arc<[RwLock<ConnectionStatus>]>) -> Self {
+    pub fn new(
+        config: PlayerConfig,
+        local_connect_status: Arc<[RwLock<ConnectionStatus>]>,
+    ) -> Self {
         let input_queues = Self::create_queues(&config);
         Self {
             saved_state: Default::default(),

--- a/backroll/src/sync.rs
+++ b/backroll/src/sync.rs
@@ -1,7 +1,7 @@
 use crate::{
     input::{FrameInput, GameInput, InputQueue},
     protocol::ConnectionStatus,
-    BackrollConfig, BackrollError, BackrollResult, Frame, SessionCallbacks, NULL_FRAME,
+    Config, BackrollError, BackrollResult, Frame, SessionCallbacks, NULL_FRAME,
 };
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -9,20 +9,20 @@ use tracing::{debug, info, warn};
 
 const MAX_PREDICTION_FRAMES: usize = 8;
 
-pub struct Config {
+pub struct PlayerConfig {
     pub player_count: usize,
 }
 
 pub struct SavedFrame<T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
     frame: super::Frame,
     data: Option<Box<T::State>>,
     checksum: Option<u64>,
 }
 
-impl<T: BackrollConfig> Default for SavedFrame<T> {
+impl<T: Config> Default for SavedFrame<T> {
     fn default() -> Self {
         Self {
             frame: NULL_FRAME,
@@ -34,13 +34,13 @@ impl<T: BackrollConfig> Default for SavedFrame<T> {
 
 pub struct SavedState<T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
     head: usize,
     frames: [SavedFrame<T>; MAX_PREDICTION_FRAMES + 2],
 }
 
-impl<T: BackrollConfig> SavedState<T> {
+impl<T: Config> SavedState<T> {
     pub fn push(&mut self, frame: SavedFrame<T>) {
         self.head += 1;
         self.head %= self.frames.len();
@@ -60,7 +60,7 @@ impl<T: BackrollConfig> SavedState<T> {
     }
 }
 
-impl<T: BackrollConfig> Default for SavedState<T> {
+impl<T: Config> Default for SavedState<T> {
     fn default() -> Self {
         Self {
             // This should lead the first one saved frame to be at
@@ -71,13 +71,13 @@ impl<T: BackrollConfig> Default for SavedState<T> {
     }
 }
 
-pub(crate) struct BackrollSync<T>
+pub(crate) struct Sync<T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
     saved_state: SavedState<T>,
     input_queues: Vec<InputQueue<T>>,
-    config: Config,
+    config: PlayerConfig,
     rolling_back: bool,
 
     last_confirmed_frame: Frame,
@@ -85,8 +85,8 @@ where
     local_connect_status: Arc<[RwLock<ConnectionStatus>]>,
 }
 
-impl<T: BackrollConfig> BackrollSync<T> {
-    pub fn new(config: Config, local_connect_status: Arc<[RwLock<ConnectionStatus>]>) -> Self {
+impl<T: Config> Sync<T> {
+    pub fn new(config: PlayerConfig, local_connect_status: Arc<[RwLock<ConnectionStatus>]>) -> Self {
         let input_queues = Self::create_queues(&config);
         Self {
             saved_state: Default::default(),

--- a/bevy_backroll/src/lib.rs
+++ b/bevy_backroll/src/lib.rs
@@ -1,6 +1,4 @@
-use backroll::{
-    Config, Event, PlayerHandle, GameInput, P2PSession, SessionCallbacks,
-};
+use backroll::{Config, Event, GameInput, P2PSession, PlayerHandle, SessionCallbacks};
 use bevy_ecs::{
     schedule::{Schedule, ShouldRun, Stage},
     system::System,
@@ -51,8 +49,7 @@ where
     schedule: Schedule,
     run_criteria: Option<Box<dyn System<In = (), Out = ShouldRun>>>,
     run_criteria_initialized: bool,
-    input_sample_fn:
-        Box<dyn System<In = PlayerHandle, Out = T::Input> + Send + Sync + 'static>,
+    input_sample_fn: Box<dyn System<In = PlayerHandle, Out = T::Input> + Send + Sync + 'static>,
     save_world_fn: Box<dyn System<In = (), Out = (T::State, Option<u64>)> + Send + Sync + 'static>,
     load_world_fn: Box<dyn System<In = T::State, Out = ()> + Send + Sync + 'static>,
 }

--- a/bevy_backroll/src/lib.rs
+++ b/bevy_backroll/src/lib.rs
@@ -1,5 +1,5 @@
 use backroll::{
-    BackrollConfig, BackrollEvent, BackrollPlayerHandle, GameInput, P2PSession, SessionCallbacks,
+    Config, Event, PlayerHandle, GameInput, P2PSession, SessionCallbacks,
 };
 use bevy_ecs::{
     schedule::{Schedule, ShouldRun, Stage},
@@ -9,9 +9,9 @@ use bevy_ecs::{
 
 pub const BACKROLL_UPDATE: &str = "backroll_update";
 
-struct BackrollStageCallbacks<'a, T>
+struct StageCallbacks<'a, T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
     world: &'a mut World,
     schedule: &'a mut Schedule,
@@ -21,7 +21,7 @@ where
     data: std::marker::PhantomData<T>,
 }
 
-impl<'a, T: BackrollConfig> SessionCallbacks<T> for BackrollStageCallbacks<'a, T> {
+impl<'a, T: Config> SessionCallbacks<T> for StageCallbacks<'a, T> {
     fn save_state(&mut self) -> (T::State, Option<u64>) {
         self.save_world_fn.run((), self.world)
     }
@@ -39,25 +39,25 @@ impl<'a, T: BackrollConfig> SessionCallbacks<T> for BackrollStageCallbacks<'a, T
         self.schedule.run_once(self.world);
     }
 
-    fn handle_event(&mut self, _: BackrollEvent) {
+    fn handle_event(&mut self, _: Event) {
         // TODO(james7132): Figure out how this will work.
     }
 }
 
 pub struct BackrollStage<T>
 where
-    T: BackrollConfig,
+    T: Config,
 {
     schedule: Schedule,
     run_criteria: Option<Box<dyn System<In = (), Out = ShouldRun>>>,
     run_criteria_initialized: bool,
     input_sample_fn:
-        Box<dyn System<In = BackrollPlayerHandle, Out = T::Input> + Send + Sync + 'static>,
+        Box<dyn System<In = PlayerHandle, Out = T::Input> + Send + Sync + 'static>,
     save_world_fn: Box<dyn System<In = (), Out = (T::State, Option<u64>)> + Send + Sync + 'static>,
     load_world_fn: Box<dyn System<In = T::State, Out = ()> + Send + Sync + 'static>,
 }
 
-impl<T: BackrollConfig> Stage for BackrollStage<T> {
+impl<T: Config> Stage for BackrollStage<T> {
     fn run(&mut self, world: &mut World) {
         loop {
             let should_run = if let Some(ref mut run_criteria) = self.run_criteria {
@@ -86,7 +86,7 @@ impl<T: BackrollConfig> Stage for BackrollStage<T> {
 
             world.insert_resource(GameInput::<T::Input>::default());
             {
-                let mut callbacks = BackrollStageCallbacks::<T> {
+                let mut callbacks = StageCallbacks::<T> {
                     world,
                     schedule: &mut self.schedule,
                     save_world_fn: self.save_world_fn.as_mut(),


### PR DESCRIPTION
This PR renames the following:
- `BackrollConfig` to `Config`
- `BackrollPlayer` to `Player`
- `BackrollPlayerHandle` to `PlayerHandle`
- `BackrollEvent` to `Event`
- `BackrollPeer` to `Peer`
- `BackrollPeerConfig` to `PeerConfig`
- `BackrollSync` to `Sync`
- `backroll::sync::Config` to `PlayerConfig`
- `bevy_backroll::BackrollStageCallbacks` to `StageCallbacks`

To avoid naming conflicts in `protocol/mod.rs`, `transport::Peer` is namespaced as `TransportPeer` and `protocol::Event` is namespaced to `ProtocolEvent`. 

I also took the liberty of addressing default clippy warnings. 

Let me know if any of these changes aren't acceptable 🙂