### PR TITLE
Replace SessionCallbacks with a Command Buffer.

### DIFF
--- a/backroll/src/backend/p2p.rs
+++ b/backroll/src/backend/p2p.rs
@@ -742,9 +742,9 @@ impl<T: Config> P2PSession<T> {
 
     /// Polls the network events. This should always be called before every frame of the game
     /// regardless of if the game is advancing it's state or not.
-    pub fn poll(&self) -> Vec<Command<T>> {
+    pub fn poll(&self) -> Commands<T> {
         let mut session_ref = self.0.write();
-        let mut commands = Vec::new();
+        let mut commands = Commands::default();
         session_ref.do_poll(&mut commands);
         commands
     }

--- a/backroll/src/command.rs
+++ b/backroll/src/command.rs
@@ -3,7 +3,7 @@ use crate::{
     sync::{SavedCell, SavedFrame},
     Config, Event, Frame,
 };
-use tracing::info;
+use tracing::{error, info};
 
 pub enum Command<T>
 where
@@ -66,7 +66,7 @@ impl<T: Config> SaveState<T> {
 impl<T: Config> Drop for SaveState<T> {
     fn drop(&mut self) {
         if !self.cell.is_valid() {
-            panic!("A SaveState command was dropped without saving a valid state.");
+            error!("A SaveState command was dropped without saving a valid state.");
         }
     }
 }

--- a/backroll/src/command.rs
+++ b/backroll/src/command.rs
@@ -1,0 +1,76 @@
+use crate::{
+    input::GameInput,
+    sync::{SavedCell, SavedFrame},
+    Config, Event, Frame,
+};
+
+pub enum Command<T>
+where
+    T: Config,
+{
+    Save(SaveState<T>),
+    Load(LoadState<T>),
+    AdvanceFrame(GameInput<T::Input>),
+    Event(Event),
+}
+
+/// A command for saving the state of the game.
+///
+/// Consumers MUST call save before the command is dropped. In debug mode,
+/// failure to do so will panic.
+pub struct SaveState<T>
+where
+    T: Config,
+{
+    pub(crate) cell: SavedCell<T>,
+    pub(crate) frame: Frame,
+}
+
+impl<T: Config> SaveState<T> {
+    pub(crate) fn new(cell: SavedCell<T>, frame: Frame) -> Self {
+        Self { cell, frame }
+    }
+
+    /// Saves a single frame's state to the session's state buffer.
+    ///
+    /// Note this consumes the SaveState, saving multiple times is
+    /// not allowed.
+    pub fn save(mut self, state: T::State, checksum: Option<u64>) {
+        self.cell.save(SavedFrame::<T> {
+            frame: self.frame,
+            data: Some(Box::new(state)),
+            checksum,
+        });
+        debug_assert!(self.cell.is_valid());
+    }
+}
+
+#[cfg(debug_assertions)]
+impl<'a, T: Config> Drop for SaveState<T> {
+    fn drop(&mut self) {
+        if !self.cell.is_valid() {
+            panic!("A SaveState command was dropped without saving a valid state.");
+        }
+    }
+}
+
+/// A command for loading a saved state of the game.
+pub struct LoadState<T>
+where
+    T: Config,
+{
+    pub(crate) cell: SavedCell<T>,
+}
+
+impl<T: Config> LoadState<T> {
+    /// Loads the saved state of the game.
+    ///
+    /// This will clone the internal copy ofthe save state. For games with
+    /// potentially large save state, this might be expensive.
+    ///
+    /// Note this consumes the LoadState, loading multiple times is
+    /// not allowed.
+    pub fn load(self) -> T::State {
+        self.cell.load()
+    }
+}

--- a/backroll/src/lib.rs
+++ b/backroll/src/lib.rs
@@ -58,31 +58,6 @@ pub trait Config: 'static {
     const RECOMMENDATION_INTERVAL: u32;
 }
 
-pub trait SessionCallbacks<T>
-where
-    T: Config,
-{
-    /// The client should copy the entire contents of the current game state into a
-    ///  new state struct and return it.
-    ///
-    /// Optionally, the client can compute a 64-bit checksum of the data and return it.
-    fn save_state(&mut self) -> (T::State, Option<u64>);
-
-    /// Backroll will call this function at the beginning of a rollback. The argument
-    /// provided will be a previously saved state returned from the save_state function.  
-    /// The client should make the current game state match the state contained in the
-    /// argument.
-    fn load_state(&mut self, state: T::State);
-
-    /// Called during a rollback.  You should advance your game state by exactly one frame.  
-    /// `inputs` will contain the inputs you should use for the given frame.
-    fn advance_frame(&mut self, input: GameInput<T::Input>);
-
-    ///  Notification that something has happened. See the `[BackcrollEvent]`
-    /// struct for more information.
-    fn handle_event(&mut self, event: Event);
-}
-
 #[derive(Clone, Debug, Error)]
 pub enum BackrollError {
     #[error("Multiple players ")]

--- a/backroll/src/lib.rs
+++ b/backroll/src/lib.rs
@@ -10,7 +10,7 @@ mod time_sync;
 
 pub use backend::*;
 pub use backroll_transport as transport;
-pub use command::Command;
+pub use command::{Command, Commands};
 pub use input::GameInput;
 
 // TODO(james7132): Generalize the executor for these.

--- a/backroll/src/lib.rs
+++ b/backroll/src/lib.rs
@@ -1,15 +1,16 @@
 use std::time::Duration;
 use thiserror::Error;
 
-mod protocol;
-
 mod backend;
+mod command;
 mod input;
+mod protocol;
 mod sync;
 mod time_sync;
 
 pub use backend::*;
 pub use backroll_transport as transport;
+pub use command::Command;
 pub use input::GameInput;
 
 // TODO(james7132): Generalize the executor for these.

--- a/backroll/src/sync.rs
+++ b/backroll/src/sync.rs
@@ -1,7 +1,8 @@
 use crate::{
+    command::{LoadState, SaveState},
     input::{FrameInput, GameInput, InputQueue},
     protocol::ConnectionStatus,
-    BackrollError, BackrollResult, Config, Frame, SessionCallbacks, NULL_FRAME,
+    BackrollError, BackrollResult, Command, Config, Frame, NULL_FRAME,
 };
 use parking_lot::{Mutex, RwLock};
 use std::ops::Deref;
@@ -49,6 +50,10 @@ impl<T: Config> SavedCell<T> {
 
     pub fn load(&self) -> T::State {
         let frame = self.0.lock();
+        debug!(
+            "=== Loading frame info (checksum: {:08x}).",
+            frame.checksum.unwrap_or(0)
+        );
         if let Some(data) = &frame.data {
             data.deref().clone()
         } else {
@@ -83,11 +88,11 @@ where
 }
 
 impl<T: Config> SavedState<T> {
-    pub fn push(&mut self, frame: SavedFrame<T>) {
+    pub fn push(&mut self) -> SavedCell<T> {
         self.head += 1;
         self.head %= self.frames.len();
-        self.frames[self.head].save(frame);
         debug_assert!(self.head < self.frames.len());
+        self.frames[self.head].clone()
     }
 
     /// Finds a saved state for a frame.
@@ -173,14 +178,14 @@ impl<T: Config> Sync<T> {
         self.input_queues[queue].set_frame_delay(delay);
     }
 
-    pub fn increment_frame(&mut self, callbacks: &mut impl SessionCallbacks<T>) {
+    pub fn increment_frame(&mut self, commands: &mut Vec<Command<T>>) {
         if self.frame_count == 0 {
-            self.save_current_frame(callbacks);
+            self.save_current_frame(commands);
         }
         let inputs = self.synchronize_inputs();
-        callbacks.advance_frame(inputs);
+        commands.push(Command::AdvanceFrame(inputs));
         self.frame_count += 1;
-        self.save_current_frame(callbacks);
+        self.save_current_frame(commands);
     }
 
     pub fn add_local_input(&mut self, queue: usize, input: T::Input) -> BackrollResult<Frame> {
@@ -240,9 +245,9 @@ impl<T: Config> Sync<T> {
         output
     }
 
-    pub fn check_simulation(&mut self, callbacks: &mut impl SessionCallbacks<T>) {
+    pub fn check_simulation(&mut self, commands: &mut Vec<Command<T>>) {
         if let Some(seek_to) = self.check_simulation_consistency() {
-            self.adjust_simulation(callbacks, seek_to);
+            self.adjust_simulation(commands, seek_to);
         }
     }
 
@@ -250,7 +255,7 @@ impl<T: Config> Sync<T> {
         self.saved_state.latest()
     }
 
-    pub fn load_frame(&mut self, callbacks: &mut impl SessionCallbacks<T>, frame: Frame) {
+    pub fn load_frame(&mut self, commands: &mut Vec<Command<T>>, frame: Frame) {
         // find the frame in question
         if frame == self.frame_count {
             info!("Skipping NOP.");
@@ -258,23 +263,11 @@ impl<T: Config> Sync<T> {
         }
 
         // Move the head pointer back and load it up
-        let state = self
+        let cell = self
             .saved_state
             .find(frame)
             .unwrap_or_else(|| panic!("Could not find saved frame index for frame: {}", frame));
-        let state = state.0.lock();
-
-        debug!(
-            "=== Loading frame info (checksum: {:08x}).",
-            state.checksum.unwrap_or(0)
-        );
-        callbacks.load_state(
-            state
-                .data
-                .as_deref()
-                .cloned()
-                .expect("Should not be loading unsaved frames"),
-        );
+        commands.push(Command::Load(LoadState::<T> { cell }));
 
         // Reset framecount and the head of the state ring-buffer to point in
         // advance of the current frame (as if we had just finished executing it).
@@ -282,21 +275,15 @@ impl<T: Config> Sync<T> {
         self.saved_state.head = (self.saved_state.head + 1) % self.saved_state.frames.len();
     }
 
-    pub fn save_current_frame(&mut self, callbacks: &mut impl SessionCallbacks<T>) {
-        let (data, checksum) = callbacks.save_state();
-        self.saved_state.push(SavedFrame::<T> {
+    pub fn save_current_frame(&mut self, commands: &mut Vec<Command<T>>) {
+        let cell = self.saved_state.push();
+        commands.push(Command::Save(SaveState::<T> {
+            cell,
             frame: self.frame_count,
-            data: Some(Box::new(data)),
-            checksum,
-        });
-        info!(
-            "=== Saved frame info {} (checksum: {:08x}).",
-            self.frame_count,
-            checksum.unwrap_or(0)
-        );
+        }));
     }
 
-    pub fn adjust_simulation(&mut self, callbacks: &mut impl SessionCallbacks<T>, seek_to: Frame) {
+    pub fn adjust_simulation(&mut self, commands: &mut Vec<Command<T>>, seek_to: Frame) {
         let frame_count = self.frame_count;
         let count = self.frame_count - seek_to;
 
@@ -304,14 +291,14 @@ impl<T: Config> Sync<T> {
         self.rolling_back = true;
 
         //  Flush our input queue and load the last frame.
-        self.load_frame(callbacks, seek_to);
+        self.load_frame(commands, seek_to);
         debug_assert!(self.frame_count == seek_to);
 
         // Advance frame by frame (stuffing notifications back to
         // the master).
         self.reset_prediction(self.frame_count);
         for _ in 0..count {
-            self.increment_frame(callbacks);
+            self.increment_frame(commands);
         }
         debug_assert!(self.frame_count == frame_count);
 

--- a/backroll/src/sync.rs
+++ b/backroll/src/sync.rs
@@ -3,7 +3,8 @@ use crate::{
     protocol::ConnectionStatus,
     BackrollError, BackrollResult, Config, Frame, SessionCallbacks, NULL_FRAME,
 };
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
+use std::ops::Deref;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
@@ -13,13 +14,14 @@ pub struct PlayerConfig {
     pub player_count: usize,
 }
 
-pub struct SavedFrame<T>
+#[derive(Clone)]
+pub(crate) struct SavedFrame<T>
 where
     T: Config,
 {
-    frame: super::Frame,
-    data: Option<Box<T::State>>,
-    checksum: Option<u64>,
+    pub frame: super::Frame,
+    pub data: Option<Box<T::State>>,
+    pub checksum: Option<u64>,
 }
 
 impl<T: Config> Default for SavedFrame<T> {
@@ -32,31 +34,74 @@ impl<T: Config> Default for SavedFrame<T> {
     }
 }
 
-pub struct SavedState<T>
+pub(crate) struct SavedCell<T>(Arc<Mutex<SavedFrame<T>>>)
+where
+    T: Config;
+
+impl<T: Config> SavedCell<T> {
+    pub fn reset(&self) {
+        *self.0.lock() = Default::default();
+    }
+
+    pub fn save(&self, frame: SavedFrame<T>) {
+        *self.0.lock() = frame;
+    }
+
+    pub fn load(&self) -> T::State {
+        let frame = self.0.lock();
+        if let Some(data) = &frame.data {
+            data.deref().clone()
+        } else {
+            panic!("Trying to load data that wasn't saved to.")
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        let frame = self.0.lock();
+        frame.data.is_some() && !crate::is_null(frame.frame)
+    }
+}
+
+impl<T: Config> Default for SavedCell<T> {
+    fn default() -> Self {
+        Self(Arc::new(Mutex::new(Default::default())))
+    }
+}
+
+impl<T: Config> Clone for SavedCell<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+pub(crate) struct SavedState<T>
 where
     T: Config,
 {
     head: usize,
-    frames: [SavedFrame<T>; MAX_PREDICTION_FRAMES + 2],
+    frames: [SavedCell<T>; MAX_PREDICTION_FRAMES + 2],
 }
 
 impl<T: Config> SavedState<T> {
     pub fn push(&mut self, frame: SavedFrame<T>) {
         self.head += 1;
         self.head %= self.frames.len();
-        self.frames[self.head] = frame;
+        self.frames[self.head].save(frame);
         debug_assert!(self.head < self.frames.len());
     }
 
     /// Finds a saved state for a frame.
-    pub fn find(&self, frame: Frame) -> Option<&SavedFrame<T>> {
-        self.frames.iter().find(|saved| saved.frame == frame)
+    pub fn find(&self, frame: Frame) -> Option<SavedCell<T>> {
+        self.frames
+            .iter()
+            .find(|saved| saved.0.lock().frame == frame)
+            .cloned()
     }
 
     /// Peeks at the latest saved frame in the queue.
-    pub fn latest(&self) -> &SavedFrame<T> {
+    pub fn latest(&self) -> SavedCell<T> {
         debug_assert!(self.head < self.frames.len());
-        &self.frames[self.head]
+        self.frames[self.head].clone()
     }
 }
 
@@ -201,7 +246,7 @@ impl<T: Config> Sync<T> {
         }
     }
 
-    pub fn get_last_saved_frame(&self) -> &SavedFrame<T> {
+    pub fn get_last_saved_frame(&self) -> SavedCell<T> {
         self.saved_state.latest()
     }
 
@@ -217,6 +262,7 @@ impl<T: Config> Sync<T> {
             .saved_state
             .find(frame)
             .unwrap_or_else(|| panic!("Could not find saved frame index for frame: {}", frame));
+        let state = state.0.lock();
 
         debug!(
             "=== Loading frame info (checksum: {:08x}).",

--- a/backroll/src/sync.rs
+++ b/backroll/src/sync.rs
@@ -1,5 +1,5 @@
 use crate::{
-    command::{LoadState, SaveState},
+    command::{Commands, LoadState, SaveState},
     input::{FrameInput, GameInput, InputQueue},
     protocol::ConnectionStatus,
     BackrollError, BackrollResult, Command, Config, Frame, NULL_FRAME,
@@ -178,7 +178,7 @@ impl<T: Config> Sync<T> {
         self.input_queues[queue].set_frame_delay(delay);
     }
 
-    pub fn increment_frame(&mut self, commands: &mut Vec<Command<T>>) {
+    pub fn increment_frame(&mut self, commands: &mut Commands<T>) {
         if self.frame_count == 0 {
             self.save_current_frame(commands);
         }
@@ -245,7 +245,7 @@ impl<T: Config> Sync<T> {
         output
     }
 
-    pub fn check_simulation(&mut self, commands: &mut Vec<Command<T>>) {
+    pub fn check_simulation(&mut self, commands: &mut Commands<T>) {
         if let Some(seek_to) = self.check_simulation_consistency() {
             self.adjust_simulation(commands, seek_to);
         }
@@ -255,7 +255,7 @@ impl<T: Config> Sync<T> {
         self.saved_state.latest()
     }
 
-    pub fn load_frame(&mut self, commands: &mut Vec<Command<T>>, frame: Frame) {
+    pub fn load_frame(&mut self, commands: &mut Commands<T>, frame: Frame) {
         // find the frame in question
         if frame == self.frame_count {
             info!("Skipping NOP.");
@@ -275,7 +275,7 @@ impl<T: Config> Sync<T> {
         self.saved_state.head = (self.saved_state.head + 1) % self.saved_state.frames.len();
     }
 
-    pub fn save_current_frame(&mut self, commands: &mut Vec<Command<T>>) {
+    pub fn save_current_frame(&mut self, commands: &mut Commands<T>) {
         let cell = self.saved_state.push();
         commands.push(Command::Save(SaveState::<T> {
             cell,
@@ -283,7 +283,7 @@ impl<T: Config> Sync<T> {
         }));
     }
 
-    pub fn adjust_simulation(&mut self, commands: &mut Vec<Command<T>>, seek_to: Frame) {
+    pub fn adjust_simulation(&mut self, commands: &mut Commands<T>, seek_to: Frame) {
         let frame_count = self.frame_count;
         let count = self.frame_count - seek_to;
 

--- a/bevy_backroll/src/lib.rs
+++ b/bevy_backroll/src/lib.rs
@@ -1,4 +1,4 @@
-use backroll::{Command, Config, GameInput, P2PSession, PlayerHandle};
+use backroll::{Command, Commands, Config, GameInput, P2PSession, PlayerHandle};
 use bevy_ecs::{
     schedule::{Schedule, ShouldRun, Stage},
     system::System,
@@ -21,7 +21,7 @@ where
 }
 
 impl<T: Config> BackrollStage<T> {
-    fn run_commands(&mut self, commands: Vec<Command<T>>, world: &mut World) {
+    fn run_commands(&mut self, commands: Commands<T>, world: &mut World) {
         for command in commands {
             match command {
                 Command::<T>::Save(save_state) => {

--- a/bevy_backroll/src/lib.rs
+++ b/bevy_backroll/src/lib.rs
@@ -1,4 +1,4 @@
-use backroll::{Config, Event, GameInput, P2PSession, PlayerHandle, SessionCallbacks};
+use backroll::{Command, Config, GameInput, P2PSession, PlayerHandle};
 use bevy_ecs::{
     schedule::{Schedule, ShouldRun, Stage},
     system::System,
@@ -7,41 +7,6 @@ use bevy_ecs::{
 use tracing::error;
 
 pub const BACKROLL_UPDATE: &str = "backroll_update";
-
-struct StageCallbacks<'a, T>
-where
-    T: Config,
-{
-    world: &'a mut World,
-    schedule: &'a mut Schedule,
-    save_world_fn:
-        &'a mut (dyn System<In = (), Out = (T::State, Option<u64>)> + Send + Sync + 'static),
-    load_world_fn: &'a mut (dyn System<In = T::State, Out = ()> + Send + Sync + 'static),
-    data: std::marker::PhantomData<T>,
-}
-
-impl<'a, T: Config> SessionCallbacks<T> for StageCallbacks<'a, T> {
-    fn save_state(&mut self) -> (T::State, Option<u64>) {
-        self.save_world_fn.run((), self.world)
-    }
-
-    fn load_state(&mut self, state: T::State) {
-        self.load_world_fn.run(state, self.world);
-    }
-
-    fn advance_frame(&mut self, input: GameInput<T::Input>) {
-        // Insert input via Resource
-        *self
-            .world
-            .get_resource_mut::<GameInput<T::Input>>()
-            .unwrap() = input;
-        self.schedule.run_once(self.world);
-    }
-
-    fn handle_event(&mut self, _: Event) {
-        // TODO(james7132): Figure out how this will work.
-    }
-}
 
 pub struct BackrollStage<T>
 where
@@ -53,6 +18,30 @@ where
     input_sample_fn: Box<dyn System<In = PlayerHandle, Out = T::Input> + Send + Sync + 'static>,
     save_world_fn: Box<dyn System<In = (), Out = (T::State, Option<u64>)> + Send + Sync + 'static>,
     load_world_fn: Box<dyn System<In = T::State, Out = ()> + Send + Sync + 'static>,
+}
+
+impl<T: Config> BackrollStage<T> {
+    fn run_commands(&mut self, commands: Vec<Command<T>>, world: &mut World) {
+        for command in commands {
+            match command {
+                Command::<T>::Save(save_state) => {
+                    let (state, checksum) = self.save_world_fn.run((), world);
+                    save_state.save(state, checksum);
+                }
+                Command::<T>::Load(load_state) => {
+                    self.load_world_fn.run(load_state.load(), world);
+                }
+                Command::AdvanceFrame(inputs) => {
+                    // Insert input via Resource
+                    *world.get_resource_mut::<GameInput<T::Input>>().unwrap() = inputs;
+                    self.schedule.run_once(world);
+                }
+                Command::Event(_) => {
+                    // TODO(james7132): Figure out how this will work.
+                }
+            }
+        }
+    }
 }
 
 impl<T: Config> Stage for BackrollStage<T> {
@@ -75,16 +64,7 @@ impl<T: Config> Stage for BackrollStage<T> {
                 return;
             };
 
-            {
-                let mut callbacks = StageCallbacks::<T> {
-                    world,
-                    schedule: &mut self.schedule,
-                    save_world_fn: self.save_world_fn.as_mut(),
-                    load_world_fn: self.load_world_fn.as_mut(),
-                    data: Default::default(),
-                };
-                session.poll(&mut callbacks);
-            }
+            self.run_commands(session.poll(), world);
 
             for player_handle in session.local_players() {
                 let input = self.input_sample_fn.run(player_handle, world);
@@ -98,16 +78,7 @@ impl<T: Config> Stage for BackrollStage<T> {
             }
 
             world.insert_resource(GameInput::<T::Input>::default());
-            {
-                let mut callbacks = StageCallbacks::<T> {
-                    world,
-                    schedule: &mut self.schedule,
-                    save_world_fn: self.save_world_fn.as_mut(),
-                    load_world_fn: self.load_world_fn.as_mut(),
-                    data: Default::default(),
-                };
-                session.advance_frame(&mut callbacks);
-            }
+            self.run_commands(session.advance_frame(), world);
             world.remove_resource::<GameInput<T::Input>>();
 
             if let ShouldRun::Yes = should_run {


### PR DESCRIPTION
This implements the proposal from #6.

 - Moves `SavedFrame` behind a `Arc<Mutex<_>>` wrapper called `SavedCell` for safely passing back to the API consumer in the form of `Command`s. This should allow a safer targeted control
 - `SaveState` and `LoadState` are made to be single-use write-through structs that allow loading and saving game state in a controlled manner.
 - `SaveState` implements `Drop` in debug mode only, which will panic if the provided client implementation did not write out to its `SavedCell` before dropping it.
 - Replaced all `&mut impl SessionCallbacks<T>` with `&mut Vec<Command<T>>` instead.

This has the added benefit of removing another generic parameter from all of the associated functions, so compile times should be faster.

The public facing API is simpler, is more idiomatic than the callbacks being used from before, and removes the nasty lifetime interactions it had with reference based callbacks from before.

Currently missing:

 - [x] a newtyped `Commands` and `CommandsIterator` types that strictly forbid all operations other than non-consuming iteration and sequential construction to ensure correctness on both the client and Backroll's ends.

Still a draft. There are some notable parts that require alteration to help prevent users of the API from shooting themselves in the foot.