### PR TITLE
Improve bevy_backroll API ergonomics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: [stable, nightly]
+        toolchain: [stable]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2" # Needed by Bevy/wgpu
 members = [
   "backroll",
   "bevy_backroll",

--- a/backroll/Cargo.toml
+++ b/backroll/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "backroll"
 version = "0.2.0"
-edition = "2018"
+edition = "2021"
 authors = ["Hourai Teahouse Developers <contact@houraiteahouse.net>"]
 description = "A pure Rust async implementation of GGPO."
 repository = "https://github.com/HouraiTeahouse/backroll-rs"

--- a/backroll/Cargo.toml
+++ b/backroll/Cargo.toml
@@ -14,7 +14,7 @@ bevy = ["bevy_tasks"]
 [dependencies]
 backroll_transport = {  path = "../backroll_transport", version = "0.1" }
 async-channel = "1.6"
-bevy_tasks = { version = "0.5", optional = true }
+bevy_tasks = { version = "0.6", optional = true }
 bincode = "1.3"
 bytemuck = "1.5"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }

--- a/backroll/src/backend/p2p.rs
+++ b/backroll/src/backend/p2p.rs
@@ -25,7 +25,7 @@ where
 {
     Local,
     Remote {
-        peer: Peer<T>,
+        peer: Box<Peer<T>>,
         rx: async_channel::Receiver<ProtocolEvent<T::Input>>,
     },
 }
@@ -54,7 +54,10 @@ impl<T: Config> PlayerType<T> {
             Player::Local => Self::Local,
             Player::Remote(peer) => {
                 let (peer, rx) = Self::make_peer(queue, peer, builder, connect, task_pool);
-                PlayerType::<T>::Remote { peer, rx }
+                PlayerType::<T>::Remote {
+                    peer: Box::new(peer),
+                    rx,
+                }
             }
         }
     }
@@ -789,7 +792,7 @@ impl<T: Config> P2PSession<T> {
         let queue = session_ref.player_handle_to_queue(player)?;
         Ok(session_ref.players[queue]
             .get_network_stats()
-            .unwrap_or_else(Default::default))
+            .unwrap_or_default())
     }
 
     /// Sets the frame delay for a given player.

--- a/backroll/src/input.rs
+++ b/backroll/src/input.rs
@@ -87,10 +87,6 @@ impl<T> FetchedInput<T> {
             Self::Prediction(input) => input,
         }
     }
-
-    pub fn is_prediction(&self) -> bool {
-        matches!(self, Self::Prediction(_))
-    }
 }
 
 pub struct InputQueue<T> {
@@ -146,11 +142,6 @@ impl<T: bytemuck::Zeroable + Clone + PartialEq> InputQueue<T> {
         }
     }
 
-    pub fn last_confirmed_frame(&self) -> Frame {
-        debug!("returning last confirmed frame {}.", self.last_added_frame);
-        self.last_added_frame
-    }
-
     pub fn first_incorrect_frame(&self) -> Frame {
         self.first_incorrect_frame
     }
@@ -196,14 +187,6 @@ impl<T: bytemuck::Zeroable + Clone + PartialEq> InputQueue<T> {
         self.prediction.frame = super::NULL_FRAME;
         self.first_incorrect_frame = super::NULL_FRAME;
         self.last_frame_requested = super::NULL_FRAME;
-    }
-
-    pub fn get_confirmed_input(&self, frame: Frame) -> Option<&FrameInput<T>> {
-        debug_assert!(
-            super::is_null(self.first_incorrect_frame) || frame < self.first_incorrect_frame
-        );
-        let offset = usize::try_from(frame).unwrap() % MAX_ROLLBACK_FRAMES;
-        self.inputs.get(offset)
     }
 
     pub fn get_input(&mut self, frame: Frame) -> FetchedInput<T> {

--- a/backroll/src/lib.rs
+++ b/backroll/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{hash::Hash, time::Duration};
+use std::time::Duration;
 use thiserror::Error;
 
 mod backend;

--- a/backroll/src/protocol/compression.rs
+++ b/backroll/src/protocol/compression.rs
@@ -79,7 +79,7 @@ pub fn decode<T: Pod>(base: &T, data: impl AsRef<[u8]>) -> Result<Vec<T>, Decode
         for (local_idx, byte) in bits.iter_mut().enumerate() {
             *byte ^= delta[idx * stride + local_idx];
         }
-        output.push(*bytemuck::try_from_bytes::<T>(&bits)?)
+        output.push(*bytemuck::try_from_bytes::<T>(bits)?)
     }
 
     Ok(output)

--- a/backroll/src/protocol/mod.rs
+++ b/backroll/src/protocol/mod.rs
@@ -94,10 +94,6 @@ impl PeerState {
         }
     }
 
-    pub fn is_disconnected(&self) -> bool {
-        matches!(self, Self::Disconnected)
-    }
-
     pub fn is_interrupted(&self) -> bool {
         matches!(self, Self::Interrupted { .. })
     }

--- a/backroll_transport/Cargo.toml
+++ b/backroll_transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "backroll_transport"
 version = "0.1.2"
-edition = "2018"
+edition = "2021"
 authors = ["Hourai Teahouse Developers <contact@houraiteahouse.net>"]
 description = "An async transport abstraction layer."
 repository = "https://github.com/HouraiTeahouse/backroll-rs"
@@ -9,7 +9,7 @@ license = "ISC"
 
 [dependencies]
 async-channel = "1.6"
-dashmap = "4.0"
+dashmap = "5.0"
 
 [dev-dependencies]
 static_assertions = "1.1"

--- a/backroll_transport/src/peers.rs
+++ b/backroll_transport/src/peers.rs
@@ -17,7 +17,7 @@ impl<T: Eq + Hash> Peers<T> {
     ///
     /// [Peer]: crate::Peer
     pub fn get(&self, id: &T) -> Option<Peer> {
-        self.0.get(&id).and_then(|kv| {
+        self.0.get(id).and_then(|kv| {
             let peer = kv.value().clone();
             if peer.is_connected() {
                 Some(peer)
@@ -28,6 +28,7 @@ impl<T: Eq + Hash> Peers<T> {
     }
 
     /// Gets the number of active connections managed by it.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.0.iter().filter(|kv| kv.value().is_connected()).count()
     }
@@ -35,7 +36,7 @@ impl<T: Eq + Hash> Peers<T> {
     /// Checks if the store has a connection to the given ID.
     pub fn contains(&self, id: &T) -> bool {
         self.0
-            .get(&id)
+            .get(id)
             .map(|kv| kv.value().is_connected())
             .unwrap_or(false)
     }
@@ -70,7 +71,7 @@ impl<T: Eq + Hash> Peers<T> {
     ///
     /// A no-op if there no Peer with the given ID.
     pub fn disconnect(&self, id: &T) {
-        if let Some((_, peer)) = self.0.remove(&id) {
+        if let Some((_, peer)) = self.0.remove(id) {
             peer.disconnect();
         }
     }

--- a/backroll_transport_steam/Cargo.toml
+++ b/backroll_transport_steam/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "backroll_transport_steam"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Hourai Teahouse Developers <contact@houraiteahouse.net>"]
 description = "A Steamworks implementation for backroll-transport."
 repository = "https://github.com/HouraiTeahouse/backroll-rs"

--- a/backroll_transport_steam/Cargo.toml
+++ b/backroll_transport_steam/Cargo.toml
@@ -18,6 +18,6 @@ docs-only = ["steamworks/docs-only"]
 [dependencies]
 backroll_transport = { path = "../backroll_transport", version = "0.1" }
 async-channel = "1.6"
-bevy_tasks = "0.5"
+bevy_tasks = "0.6"
 tracing = "0.1"
-steamworks = "0.7.0"
+steamworks = "0.8.0"

--- a/backroll_transport_steam/src/lib.rs
+++ b/backroll_transport_steam/src/lib.rs
@@ -58,7 +58,7 @@ impl SteamP2PManager {
         let manager = Self {
             peers: peers.clone(),
             client: client.clone(),
-            task_pool: pool.clone(),
+            task_pool: pool,
 
             // Register a P2P session request handler.
             _session_request: client.register_callback(move |request: P2PSessionRequest| {
@@ -99,7 +99,7 @@ impl SteamP2PManager {
         } else {
             self.peers.create_unbounded(config.remote)
         };
-        let other = self.peers.get(&config.remote).unwrap().clone();
+        let other = self.peers.get(&config.remote).unwrap();
         let client = self.client.clone();
         let task = Self::send(other, config.remote, client);
         self.task_pool.spawn(task).detach();

--- a/backroll_transport_udp/Cargo.toml
+++ b/backroll_transport_udp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "backroll_transport_udp"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Hourai Teahouse Developers <contact@houraiteahouse.net>"]
 description = "A raw async UDP implementation for backroll-transport."
 repository = "https://github.com/HouraiTeahouse/backroll-rs"

--- a/backroll_transport_udp/Cargo.toml
+++ b/backroll_transport_udp/Cargo.toml
@@ -11,7 +11,7 @@ license = "ISC"
 backroll_transport = { path = "../backroll_transport", version = "0.1" }
 async-channel = "1.6"
 async-net = "1.6.0" 
-bevy_tasks = "0.5"
+bevy_tasks = "0.6"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/backroll_transport_udp/src/lib.rs
+++ b/backroll_transport_udp/src/lib.rs
@@ -85,7 +85,7 @@ impl UdpManager {
         } else {
             self.peers.create_unbounded(config.addr)
         };
-        let other = self.peers.get(&config.addr).unwrap().clone();
+        let other = self.peers.get(&config.addr).unwrap();
         let socket = self.socket.clone();
         let task = Self::send(other, config.addr, socket);
         self.task_pool.spawn(task).detach();

--- a/bevy_backroll/Cargo.toml
+++ b/bevy_backroll/Cargo.toml
@@ -28,7 +28,7 @@ parking_lot = "0.11"
 tinyset = "0.4"
 
 # Optional dependencies
-bevy-steamworks = { version = "0.1", optional = true }
+bevy-steamworks = { version = "0.2", optional = true }
 backroll_transport_steam = { path = "../backroll_transport_steam", version = "0.1", optional = true }
 
 [dev-dependencies]

--- a/bevy_backroll/Cargo.toml
+++ b/bevy_backroll/Cargo.toml
@@ -18,11 +18,13 @@ docs-only = ["steam", "backroll_transport_steam/docs-only"]
 
 [dependencies]
 backroll = { path = "../backroll", version = "0.2" }
+bytemuck = "1.5"
 bevy_ecs = "0.6"
 bevy_core = "0.6"
 bevy_tasks = "0.6"
 bevy_app = "0.6"
 bevy_log = "0.6"
+parking_lot = "0.11"
 
 # Optional dependencies
 bevy-steamworks = { version = "0.1", optional = true }

--- a/bevy_backroll/Cargo.toml
+++ b/bevy_backroll/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_backroll"
 version = "0.2.0"
-edition = "2018"
+edition = "2021"
 authors = ["Hourai Teahouse Developers <contact@houraiteahouse.net>"]
 description = "A Bevy engine integration plugin for the backroll rollback networking library."
 repository = "https://github.com/HouraiTeahouse/backroll-rs"

--- a/bevy_backroll/Cargo.toml
+++ b/bevy_backroll/Cargo.toml
@@ -25,6 +25,7 @@ bevy_tasks = "0.6"
 bevy_app = "0.6"
 bevy_log = "0.6"
 parking_lot = "0.11"
+tinyset = "0.4"
 
 # Optional dependencies
 bevy-steamworks = { version = "0.1", optional = true }

--- a/bevy_backroll/README.md
+++ b/bevy_backroll/README.md
@@ -13,6 +13,7 @@ rollback networking library.
 
 |Bevy Version|bevy\_backroll|
 |:-----------|:-------------|
+|0.6         |0.2           |
 |0.5         |0.1           |
 
 ## Feature Flags

--- a/bevy_backroll/src/id.rs
+++ b/bevy_backroll/src/id.rs
@@ -14,9 +14,9 @@ pub struct NetworkId(pub(crate) u32);
 /// to deterministically produce IDs across rollbacks.
 ///
 /// This resource is reset upon starting a new session via
-/// [`BackrollCommands::start_new_session`][start_new_session].
+/// [`BackrollCommands::start_backroll_session`][start_backroll_session].
 ///
-/// [start_new_session]: crate::BackrollCommands::start_new_session
+/// [start_backroll_session]: crate::BackrollCommands::start_backroll_session
 #[derive(Debug, Clone)]
 #[repr(transparent)]
 pub struct NetworkIdProvider(u32);

--- a/bevy_backroll/src/id.rs
+++ b/bevy_backroll/src/id.rs
@@ -1,0 +1,21 @@
+use bevy_ecs::component::Component;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_NETWORK_ID: AtomicU64 = AtomicU64::new(0);
+
+/// A marker [`Component`]. Required to mark entities with network state.
+///
+/// Registered network components will only be saved or loaded with this
+/// marker component present.
+/// 
+/// Backed by a `u64` generated from a global [`AtomicU64`].
+#[derive(Debug, Component, Copy, Clone, Eq, Hash, PartialEq)]
+#[repr(transparent)]
+pub struct NetworkId(u64);
+
+impl NetworkId {
+    /// Creates a new `NetworkID`.
+    pub fn new() -> Self {
+        Self(NEXT_NETWORK_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}

--- a/bevy_backroll/src/id.rs
+++ b/bevy_backroll/src/id.rs
@@ -7,7 +7,7 @@ static NEXT_NETWORK_ID: AtomicU64 = AtomicU64::new(0);
 ///
 /// Registered network components will only be saved or loaded with this
 /// marker component present.
-/// 
+///
 /// Backed by a `u64` generated from a global [`AtomicU64`].
 #[derive(Debug, Component, Copy, Clone, Eq, Hash, PartialEq)]
 #[repr(transparent)]

--- a/bevy_backroll/src/id.rs
+++ b/bevy_backroll/src/id.rs
@@ -6,20 +6,20 @@ use bevy_ecs::component::Component;
 /// marker component present.
 #[derive(Debug, Component, Copy, Clone, Eq, Hash, PartialEq)]
 #[repr(transparent)]
-pub struct NetworkId(u64);
+pub struct NetworkId(pub(crate) u32);
 
 /// A provider resource of new, globally unique [`NetworkId`] components.
-/// 
+///
 /// This resource itself is registered as a saveable resource and is guarenteed
 /// to deterministically produce IDs across rollbacks.
-/// 
-/// This resource is reset upon starting a new session via 
+///
+/// This resource is reset upon starting a new session via
 /// [`BackrollCommands::start_new_session`][start_new_session].
-/// 
+///
 /// [start_new_session]: crate::BackrollCommands::start_new_session
 #[derive(Debug, Clone)]
 #[repr(transparent)]
-pub struct NetworkIdProvider(u64);
+pub struct NetworkIdProvider(u32);
 
 impl NetworkIdProvider {
     pub(crate) fn new() -> Self {
@@ -32,7 +32,7 @@ impl NetworkIdProvider {
         self.0 = self
             .0
             .checked_add(1)
-            .expect("NetworkId has overflowed u64::MAX.");
+            .expect("NetworkId has overflowed u32::MAX.");
         id
     }
 }

--- a/bevy_backroll/src/lib.rs
+++ b/bevy_backroll/src/lib.rs
@@ -25,26 +25,31 @@ use backroll::{
     Config, Event, GameInput, P2PSession, PlayerHandle,
 };
 use bevy_app::{App, CoreStage, Events, Plugin};
-use bevy_core::FixedTimestep;
 use bevy_ecs::{
-    schedule::{IntoSystemDescriptor, Schedule, ShouldRun, Stage, SystemSet, SystemStage},
+    prelude::*,
+    schedule::{IntoSystemDescriptor, ShouldRun, Stage, SystemSet, SystemStage},
     system::{Commands as BevyCommands, System},
     world::World,
 };
 use bevy_log::{debug, error};
+use parking_lot::Mutex;
+use std::marker::PhantomData;
+use std::sync::Arc;
 
+mod save_state;
 #[cfg(feature = "steam")]
 mod steam;
 
 pub use backroll;
+use save_state::*;
 
 /// The [SystemLabel] used by the [BackrollStage] added by [BackrollPlugin].
 ///
 /// [SystemLabel]: bevy_ecs::schedule::SystemLabel
 /// [BackrollStage]: self::BackrollStage
 /// [BackrollPlugin]: self::BackrollPlugin
-pub const BACKROLL_UPDATE: &str = "backroll_update";
-const BACKROLL_LOGIC_UPDATE: &str = "backroll_logic_update";
+#[derive(Debug, Clone, Eq, Hash, StageLabel, PartialEq)]
+pub struct BackrollUpdate;
 
 /// Manages when to inject frame stalls to keep in sync with remote players.
 struct FrameStaller {
@@ -91,6 +96,27 @@ impl FrameStaller {
     }
 }
 
+struct BackrollStagesRef {
+    save: SystemStage,
+    simulate: SystemStage,
+    load: SystemStage,
+    run_criteria: Option<Box<dyn System<In = (), Out = ShouldRun>>>,
+}
+
+#[derive(Clone)]
+struct BackrollStages(Arc<Mutex<BackrollStagesRef>>);
+
+struct BevyBackrollConfig<Input> {
+    _marker: PhantomData<Input>,
+}
+
+impl<Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync> Config
+    for BevyBackrollConfig<Input>
+{
+    type Input = Input;
+    type State = SaveState;
+}
+
 /// A [Stage] that transparently runs and handles Backroll sessions.
 ///
 /// Each time the stage runs, it will poll the Backroll session, sample local player
@@ -125,59 +151,41 @@ impl FrameStaller {
 /// [with_world_save_system]: self::BackrollAppBuilder::with_world_save_system
 /// [with_world_load_system]: self::BackrollAppBuilder::with_world_save_system
 /// [with_rollback_system]: self::BackrollAppBuilder::with_rollback_system
-pub struct BackrollStage<T>
+struct BackrollStage<Input>
 where
-    T: Config,
+    Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
 {
-    pub schedule: Schedule,
-    run_criteria: Option<Box<dyn System<In = (), Out = ShouldRun>>>,
     staller: FrameStaller,
-    input_sample_fn:
-        Option<Box<dyn System<In = PlayerHandle, Out = T::Input> + Send + Sync + 'static>>,
-    save_world_fn: Option<Box<dyn System<In = (), Out = T::State> + Send + Sync + 'static>>,
-    load_world_fn: Option<Box<dyn System<In = T::State, Out = ()> + Send + Sync + 'static>>,
+    input_sample_fn: Box<dyn System<In = PlayerHandle, Out = Input> + Send + Sync + 'static>,
 }
 
-impl<T: Config> Default for BackrollStage<T> {
-    fn default() -> Self {
-        Self {
-            schedule: Default::default(),
-            run_criteria: None,
-            staller: FrameStaller::new(),
-            input_sample_fn: None,
-            save_world_fn: None,
-            load_world_fn: None,
-        }
-    }
-}
-
-impl<T: Config> BackrollStage<T> {
-    fn run_commands(&mut self, commands: Commands<T>, world: &mut World) {
+impl<Input> BackrollStage<Input>
+where
+    Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
+{
+    fn run_commands(&mut self, commands: Commands<BevyBackrollConfig<Input>>, world: &mut World) {
         for command in commands {
             match command {
-                Command::<T>::Save(save_state) => {
-                    let state = self
-                        .save_world_fn
-                        .as_mut()
-                        .expect(
-                            "No world save system found. Please use App::with_world_load_system",
-                        )
-                        .run((), world);
+                Command::Save(save_state) => {
+                    world.insert_resource(SaveStateBuilder::new());
+                    let stage = world.get_resource::<BackrollStages>().unwrap().clone();
+                    stage.0.lock().save.run(world);
                     // TODO(james7132): Find a way to hash the state here generically.
-                    save_state.save_without_hash(state);
+                    save_state.save_without_hash(
+                        world.remove_resource::<SaveStateBuilder>().unwrap().build(),
+                    );
                 }
-                Command::<T>::Load(load_state) => {
-                    self.load_world_fn
-                        .as_mut()
-                        .expect(
-                            "No world load system found. Please use App::with_world_load_system",
-                        )
-                        .run(load_state.load(), world);
+                Command::Load(load_state) => {
+                    world.insert_resource(load_state.load());
+                    let stage = world.get_resource::<BackrollStages>().unwrap().clone();
+                    stage.0.lock().load.run(world);
+                    world.remove_resource::<SaveState>();
                 }
                 Command::AdvanceFrame(inputs) => {
                     // Insert input via Resource
-                    *world.get_resource_mut::<GameInput<T::Input>>().unwrap() = inputs;
-                    self.schedule.run_once(world);
+                    *world.get_resource_mut::<GameInput<Input>>().unwrap() = inputs;
+                    let stage = world.get_resource::<BackrollStages>().unwrap().clone();
+                    stage.0.lock().simulate.run(world);
                 }
                 Command::Event(evt) => {
                     debug!("Received Backroll Event: {:?}", evt);
@@ -195,42 +203,43 @@ impl<T: Config> BackrollStage<T> {
     }
 }
 
-impl<T: Config> Stage for BackrollStage<T> {
+impl<Input> Stage for BackrollStage<Input>
+where
+    Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
+{
     fn run(&mut self, world: &mut World) {
         loop {
-            let should_run = if let Some(ref mut run_criteria) = self.run_criteria {
-                run_criteria.run((), world)
-            } else {
-                ShouldRun::Yes
+            let should_run = {
+                let stages = world.get_resource::<BackrollStages>().unwrap().clone();
+                let run_criteria = &mut stages.0.lock().run_criteria;
+                if let Some(ref mut run_criteria) = run_criteria {
+                    run_criteria.run((), world)
+                } else {
+                    ShouldRun::Yes
+                }
             };
 
             if let ShouldRun::No = should_run {
                 return;
             }
 
-            let session = if let Some(session) = world.get_resource_mut::<P2PSession<T>>() {
+            let session = if let Some(session) =
+                world.get_resource_mut::<P2PSession<BevyBackrollConfig<Input>>>()
+            {
                 session.clone()
             } else {
                 // No ongoing session, don't run.
                 return;
             };
 
-            world.insert_resource(GameInput::<T::Input>::default());
             self.run_commands(session.poll(), world);
-            world.remove_resource::<GameInput<T::Input>>();
 
             if self.staller.should_stall() {
                 continue;
             }
 
             for player_handle in session.local_players() {
-                let input = self
-                    .input_sample_fn
-                    .as_mut()
-                    .expect(
-                        "No input sampler system found. Please use App::with_input_sampler_system",
-                    )
-                    .run(player_handle, world);
+                let input = self.input_sample_fn.run(player_handle, world);
                 if let Err(err) = session.add_local_input(player_handle, input) {
                     error!(
                         "Error while adding local input for {:?}: {:?}",
@@ -240,9 +249,7 @@ impl<T: Config> Stage for BackrollStage<T> {
                 }
             }
 
-            world.insert_resource(GameInput::<T::Input>::default());
             self.run_commands(session.advance_frame(), world);
-            world.remove_resource::<GameInput<T::Input>>();
 
             if let ShouldRun::Yes = should_run {
                 return;
@@ -265,32 +272,21 @@ impl<T: Config> Stage for BackrollStage<T> {
 ///
 /// [BackrolLStage]: self::BackrollStage
 /// [Event]: backroll::Event
-pub struct BackrollPlugin<T>(std::marker::PhantomData<T>)
-where
-    T: backroll::Config + Send + Sync;
+#[derive(Default)]
+pub struct BackrollPlugin;
 
-impl<T: backroll::Config + Send + Sync> Plugin for BackrollPlugin<T> {
-    fn build(&self, builder: &mut App) {
-        let mut schedule = Schedule::default();
-        schedule.add_stage(BACKROLL_LOGIC_UPDATE, SystemStage::parallel());
-        builder.add_event::<backroll::Event>().add_stage_before(
-            CoreStage::Update,
-            BACKROLL_UPDATE,
-            BackrollStage::<T> {
-                schedule,
-                run_criteria: Some(Box::new(FixedTimestep::steps_per_second(60.0))),
-                ..Default::default()
-            },
-        );
+impl Plugin for BackrollPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<backroll::Event>()
+            .insert_resource(BackrollStages(Arc::new(Mutex::new(BackrollStagesRef {
+                save: SystemStage::parallel(),
+                simulate: SystemStage::parallel(),
+                load: SystemStage::parallel(),
+                run_criteria: None,
+            }))));
 
         #[cfg(feature = "steam")]
         builder.add_plugin(steam::BackrollSteamPlugin);
-    }
-}
-
-impl<T: Config + Send + Sync> Default for BackrollPlugin<T> {
-    fn default() -> Self {
-        Self(Default::default())
     }
 }
 
@@ -299,26 +295,14 @@ impl<T: Config + Send + Sync> Default for BackrollPlugin<T> {
 /// [App]: bevy_app::AppBuilder
 /// [BackrollPlugin]: self::BackrollPlugin
 pub trait BackrollApp {
+    fn register_rollback_component<T: Component + Clone>(&mut self) -> &mut Self;
+
     /// Sets the input sampler system for Backroll. This is required. Attempting to start
     /// a Backroll session without setting this will result in a panic.
-    fn with_input_sampler_system<T, S>(&mut self, system: S) -> &mut Self
+    fn register_rollback_input<Input, S>(&mut self, system: S) -> &mut Self
     where
-        T: backroll::Config,
-        S: System<In = PlayerHandle, Out = T::Input> + Send + Sync + 'static;
-
-    /// Sets the world save system for Backroll. This is required. Attempting to start a
-    /// Backroll session without setting this will result in a panic.
-    fn with_world_save_system<T, S>(&mut self, system: S) -> &mut Self
-    where
-        T: backroll::Config,
-        S: System<In = (), Out = T::State> + Send + Sync + 'static;
-
-    /// Sets the world load system for Backroll. This is required. Attempting to start a
-    /// Backroll session without setting this will result in a panic.
-    fn with_world_load_system<T, S>(&mut self, system: S) -> &mut Self
-    where
-        T: backroll::Config,
-        S: System<In = T::State, Out = ()> + Send + Sync + 'static;
+        Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
+        S: System<In = PlayerHandle, Out = Input> + Send + Sync + 'static;
 
     /// Sets the [RunCriteria] for the [BackrollStage]. By default this uses a [FixedTimestep]
     /// set to 60 ticks per second.
@@ -326,103 +310,101 @@ pub trait BackrollApp {
     /// [RunCriteria]: bevy_ecs::schedule::RunCriteria
     /// [BackrollStage]: self::BackrollStage
     /// [FixedTimestep]: bevy_core::FixedTimestep
-    fn with_rollback_run_criteria<T, S>(&mut self, system: S) -> &mut Self
+    fn with_rollback_run_criteria<Input, S>(&mut self, system: S) -> &mut Self
     where
-        T: backroll::Config,
+        Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
         S: System<In = (), Out = ShouldRun>;
 
     /// Adds a system to the Backroll stage.
-    fn with_rollback_system<T, S, U>(&mut self, system: S) -> &mut Self
+    fn add_rollback_system<Input, S, U>(&mut self, system: S) -> &mut Self
     where
-        T: backroll::Config,
+        Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
         S: IntoSystemDescriptor<U>;
 
     /// Adds a [SystemSet] to the BackrollStage.
     ///
     /// [SystemSet]: bevy_ecs::schedule::SystemSet
-    fn with_rollback_system_set<T: backroll::Config>(&mut self, system: SystemSet) -> &mut Self;
+    fn add_rollback_system_set<Input>(&mut self, system: SystemSet) -> &mut Self
+    where
+        Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync;
 }
 
 impl BackrollApp for App {
-    fn with_input_sampler_system<T, S>(&mut self, mut system: S) -> &mut Self
+    fn register_rollback_input<Input, S>(&mut self, system: S) -> &mut Self
     where
-        T: backroll::Config,
-        S: System<In = PlayerHandle, Out = T::Input> + Send + Sync + 'static,
+        Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
+        S: System<In = PlayerHandle, Out = Input> + Send + Sync + 'static,
     {
-        system.initialize(&mut self.world);
-        let stage = self
-            .schedule
-            .get_stage_mut::<BackrollStage<T>>(&BACKROLL_UPDATE)
-            .expect("No BackrollStage found! Did you install the plugin?");
-        stage.input_sample_fn = Some(Box::new(system));
+        self.insert_resource(GameInput::<Input>::default());
+        self.add_stage_before(
+            CoreStage::Update,
+            BackrollUpdate,
+            BackrollStage::<Input> {
+                staller: FrameStaller::new(),
+                input_sample_fn: Box::new(system),
+            },
+        );
+
         self
     }
 
-    fn with_world_save_system<T, S>(&mut self, mut system: S) -> &mut Self
-    where
-        T: backroll::Config,
-        S: System<In = (), Out = T::State> + Send + Sync + 'static,
-    {
-        system.initialize(&mut self.world);
-        let stage = self
-            .schedule
-            .get_stage_mut::<BackrollStage<T>>(&BACKROLL_UPDATE)
-            .expect("No BackrollStage found! Did you install the plugin?");
-        stage.save_world_fn = Some(Box::new(system));
+    fn register_rollback_component<T: Component + Clone>(&mut self) -> &mut Self {
+        {
+            let mut stages = self
+                .world
+                .get_resource::<BackrollStages>()
+                .expect("No BackrollStages found! Did you install the plugin?")
+                .0
+                .lock();
+
+            stages.load.add_system(load_components::<T>);
+            stages.save.add_system(save_components::<T>);
+        }
+
         self
     }
 
-    fn with_world_load_system<T, S>(&mut self, mut system: S) -> &mut Self
+    fn with_rollback_run_criteria<Input, S>(&mut self, mut run_criteria: S) -> &mut Self
     where
-        T: backroll::Config,
-        S: System<In = T::State, Out = ()> + Send + Sync + 'static,
-    {
-        system.initialize(&mut self.world);
-        let stage = self
-            .schedule
-            .get_stage_mut::<BackrollStage<T>>(&BACKROLL_UPDATE)
-            .expect("No BackrollStage found! Did you install the plugin?");
-        stage.load_world_fn = Some(Box::new(system));
-        self
-    }
-
-    fn with_rollback_run_criteria<T, S>(&mut self, mut run_criteria: S) -> &mut Self
-    where
-        T: backroll::Config,
+        Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
         S: System<In = (), Out = ShouldRun>,
     {
         run_criteria.initialize(&mut self.world);
-        let stage = self
-            .schedule
-            .get_stage_mut::<BackrollStage<T>>(&BACKROLL_UPDATE)
-            .expect("No BackrollStage found! Did you install the plugin?");
-        stage.run_criteria = Some(Box::new(run_criteria));
+        self.world
+            .get_resource::<BackrollStages>()
+            .expect("No BackrollStages found! Did you install the plugin?")
+            .0
+            .lock()
+            .run_criteria = Some(Box::new(run_criteria));
         self
     }
 
-    fn with_rollback_system<T, S, U>(&mut self, system: S) -> &mut Self
+    fn add_rollback_system<Input, S, U>(&mut self, system: S) -> &mut Self
     where
-        T: backroll::Config,
+        Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
         S: IntoSystemDescriptor<U>,
     {
-        let stage = self
-            .schedule
-            .get_stage_mut::<BackrollStage<T>>(&BACKROLL_UPDATE)
-            .expect("No BackrollStage found! Did you install the plugin?");
-        stage
-            .schedule
-            .add_system_to_stage(BACKROLL_LOGIC_UPDATE, system);
+        self.world
+            .get_resource::<BackrollStages>()
+            .expect("No BackrollStages found! Did you install the plugin?")
+            .0
+            .lock()
+            .simulate
+            .add_system(system);
         self
     }
 
-    fn with_rollback_system_set<T: backroll::Config>(&mut self, system: SystemSet) -> &mut Self {
-        let stage = self
-            .schedule
-            .get_stage_mut::<BackrollStage<T>>(&BACKROLL_UPDATE)
-            .expect("No BackrollStage found! Did you install the plugin?");
-        stage
-            .schedule
-            .add_system_set_to_stage(BACKROLL_LOGIC_UPDATE, system);
+    fn add_rollback_system_set<Input>(&mut self, system: SystemSet) -> &mut Self
+    where
+        Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
+    {
+        self.world
+            .get_resource::<BackrollStages>()
+            .expect("No BackrollStages found! Did you install the plugin?")
+            .0
+            .lock()
+            .simulate
+            .add_system_set(system);
         self
     }
 }

--- a/bevy_backroll/src/lib.rs
+++ b/bevy_backroll/src/lib.rs
@@ -308,7 +308,7 @@ impl Plugin for BackrollPlugin {
             .register_rollback_resource::<NetworkIdProvider>();
 
         #[cfg(feature = "steam")]
-        builder.add_plugin(steam::BackrollSteamPlugin);
+        app.add_plugin(steam::BackrollSteamPlugin);
     }
 }
 

--- a/bevy_backroll/src/lib.rs
+++ b/bevy_backroll/src/lib.rs
@@ -5,28 +5,52 @@
 //!
 //! Installing the plugin:
 //! ```rust no_run
+//! use backroll::*;
 //! use bytemuck::*;
 //! use bevy::prelude::*;
 //! use bevy_backroll::*;
 //!
 //! // Create your Backroll input type
-//! #[derive(Clone, Copy, Pod, Zeroable)]
-//! pub struct BackrollInput {
+//! #[repr(C)]
+//! #[derive(Clone, Copy, Eq, PartialEq, Pod, Zeroable)]
+//! pub struct PlayerInput {
 //!    // Input data...
-//! !  pub button_pressed: u64
+//!    pub buttons_pressed: u8,
+//! }
+//! 
+//! // Create your state. Must implement Clone.
+//! #[derive(Component, Clone)]
+//! pub struct PlayerState {
+//!    pub handle: PlayerHandle,
+//!    pub current_value: u64,
 //! }
 //!
-//! fn sample_player_input(player: PlayerHandle) -> BackrollInput {
+//! // Sample input from the local player's controller.
+//! fn sample_player_input(player: In<PlayerHandle>) -> PlayerInput {
 //!    // Sample input data...
-//! !   BackrollInput {
-//! !      buttons_pressed: 0,
-//! !   }
+//!    PlayerInput {
+//!       buttons_pressed: 1,
+//!    }
+//! }
+//! 
+//! // Use input to advance the game simulation.
+//! fn simulate_game(
+//!   input: Res<GameInput<PlayerInput>>,
+//!   mut query: Query<&mut PlayerState>
+//! ) {
+//!    for mut player in query.iter_mut() {
+//!       if let Ok(input) = input.get(player.handle) {
+//!          player.current_value += input.buttons_pressed as u64;
+//!       }
+//!    }
 //! }
 //!
 //! fn main() {
-//!     App::build()
+//!     App::new()
 //!         .add_plugin(BackrollPlugin)
-//!         .register_rollback_input(sample_player_input)
+//!         .register_rollback_input(sample_player_input.system())
+//!         .register_rollback_component::<PlayerState>()
+//!         .add_rollback_system(simulate_game)
 //!         .run();
 //! }
 //! ```

--- a/bevy_backroll/src/lib.rs
+++ b/bevy_backroll/src/lib.rs
@@ -297,13 +297,15 @@ impl Plugin for BackrollPlugin {
         let mut before_load = SystemStage::parallel();
         before_load.add_system(sync_network_ids);
         app.add_event::<backroll::Event>()
+            .insert_resource(NetworkIdProvider::new())
             .insert_resource(BackrollStages(Arc::new(Mutex::new(BackrollStagesRef {
                 save,
                 simulate: SystemStage::parallel(),
                 before_load,
                 load: SystemStage::parallel(),
                 run_criteria: None,
-            }))));
+            }))))
+            .register_rollback_resource::<NetworkIdProvider>();
 
         #[cfg(feature = "steam")]
         builder.add_plugin(steam::BackrollSteamPlugin);
@@ -469,6 +471,8 @@ impl<'w, 's> BackrollCommands for BevyCommands<'w, 's> {
     where
         Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
     {
+        // Reset the NetworkIdProvider on the start of a new session.
+        self.insert_resource(NetworkIdProvider::new());
         self.insert_resource(session);
     }
 

--- a/bevy_backroll/src/lib.rs
+++ b/bevy_backroll/src/lib.rs
@@ -4,7 +4,7 @@
 //! [Backroll](https://crates.io/crates/backroll) sessions.
 //!
 //! Installing the plugin:
-//! ```rust norun
+//! ```rust no_run
 //! use bytemuck::*;
 //! use bevy::prelude::*;
 //! use bevy_backroll::*;
@@ -134,12 +134,11 @@ impl<Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync> Config
 ///
 /// The stage will automatically handle Backroll commands by doing the following:
 ///  
-///  - [Command::Save]: Runs the system registered through [with_world_save_system]
-///    to make a save state of the [World].
-///  - [Command::Load]: Runs the system registered through [with_world_load_system]
-///    to restore a save state of the [World].
+///  - [Command::Save]: Saves an immutable copy of the components and resoures from the
+///    main app [`World`] into a save state.
+///  - [Command::Load]: Loads a prior saved World state into the main app [`World`].
 ///  - [Command::AdvanceFrame]: Injects the provided [GameInput] as a resource then
-///    runs all simulation based systems once (see: [with_rollback_system])
+///    runs all simulation based systems once (see: [add_rollback_system])
 ///  - [Command::Event]: Forwards all events to Bevy. Can be read out via [EventReader].
 ///    Automatically handles time synchronization by smoothly injecting stall frames when
 ///    ahead of remote players.
@@ -158,10 +157,8 @@ impl<Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync> Config
 /// [BackrollCommands]: self::BackrollCommands
 /// [FixedTimestep]: bevy_core::FixedTimestep
 /// [EventReader]: bevy_app::EventReader
-/// [with_world_save_system]: self::BackrollAppBuilder::with_world_save_system
-/// [with_world_load_system]: self::BackrollAppBuilder::with_world_save_system
-/// [with_rollback_system]: self::BackrollAppBuilder::with_rollback_system
-struct BackrollStage<Input>
+/// [add_rollback_system]: self::BackrollApp::add_rollback_system
+pub struct BackrollStage<Input>
 where
     Input: PartialEq + bytemuck::Pod + bytemuck::Zeroable + Send + Sync,
 {
@@ -302,7 +299,7 @@ impl Plugin for BackrollPlugin {
 
 /// Extension trait for configuring [App]s using a [BackrollPlugin].
 ///
-/// [App]: bevy_app::AppBuilder
+/// [App]: bevy_app::App
 /// [BackrollPlugin]: self::BackrollPlugin
 pub trait BackrollApp {
     /// Sets the input sampler system for Backroll. This is required. Backroll will

--- a/bevy_backroll/src/lib.rs
+++ b/bevy_backroll/src/lib.rs
@@ -17,7 +17,7 @@
 //!    // Input data...
 //!    pub buttons_pressed: u8,
 //! }
-//! 
+//!
 //! // Create your state. Must implement Clone.
 //! #[derive(Component, Clone)]
 //! pub struct PlayerState {
@@ -32,7 +32,7 @@
 //!       buttons_pressed: 1,
 //!    }
 //! }
-//! 
+//!
 //! // Use input to advance the game simulation.
 //! fn simulate_game(
 //!   input: Res<GameInput<PlayerInput>>,

--- a/bevy_backroll/src/save_state.rs
+++ b/bevy_backroll/src/save_state.rs
@@ -1,0 +1,88 @@
+use bevy_ecs::prelude::*;
+use bevy_log::*;
+use std::any::*;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Clone)]
+struct ComponentSlab<T: Clone> {
+    components: Vec<T>,
+    entities: Vec<Entity>,
+}
+
+/// A mutable builder for [`SaveState`]s.
+pub struct SaveStateBuilder {
+    components: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
+}
+
+impl SaveStateBuilder {
+    pub fn new() -> Self {
+        Self {
+            components: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn save_components<T: Component + Clone>(&mut self, query: Query<(Entity, &T)>) {
+        let mut components = Vec::new();
+        let mut entities = Vec::new();
+        for (entity, component) in query.iter() {
+            entities.push(entity);
+            components.push(component.clone());
+        }
+        self.components.insert(
+            TypeId::of::<T>(),
+            Box::new(ComponentSlab {
+                components,
+                entities,
+            }),
+        );
+    }
+
+    pub fn build(self) -> SaveState {
+        SaveState(Arc::new(self))
+    }
+}
+
+/// A read only save state of a Bevy world.
+#[derive(Clone)]
+pub struct SaveState(Arc<SaveStateBuilder>);
+
+impl SaveState {
+    pub(crate) fn load_components<T: Component + Clone>(&self, mut query: Query<&mut T>) {
+        let slab = self
+            .0
+            .components
+            .get(&TypeId::of::<T>())
+            .unwrap()
+            .downcast_ref::<ComponentSlab<T>>()
+            .unwrap();
+
+        // HACK: This is REALLY going to screw with any change detection on these types.
+        for (entity, component) in slab.entities.iter().zip(slab.components.iter()) {
+            if let Ok(mut comp) = query.get_mut(*entity) {
+                *comp = component.clone();
+            } else {
+                warn!(
+                    "Attempted to load component '{}' from a save state for entity {:?} but the entity no longer exists.",
+                    type_name::<T>(),
+                    entity
+                )
+            }
+        }
+    }
+}
+
+// This disallows parallelization while saving. Is this design OK?
+pub(crate) fn save_components<T: Component + Clone>(
+    mut save_state: ResMut<SaveStateBuilder>,
+    query: Query<(Entity, &T)>,
+) {
+    save_state.save_components(query);
+}
+
+pub(crate) fn load_components<T: Component + Clone>(
+    save_state: Res<SaveState>,
+    query: Query<&mut T>,
+) {
+    save_state.load_components(query);
+}

--- a/bevy_backroll/src/save_state.rs
+++ b/bevy_backroll/src/save_state.rs
@@ -1,18 +1,16 @@
 use bevy_ecs::prelude::*;
-use bevy_log::*;
+use parking_lot::Mutex;
 use std::any::*;
 use std::collections::HashMap;
 use std::sync::Arc;
-use parking_lot::Mutex;
 
 #[derive(Clone)]
-struct ComponentSlab<T: Clone> {
-    components: Vec<T>,
-    entities: Vec<Entity>,
+struct SavedComponents<T: Clone> {
+    components: HashMap<Entity, T>,
 }
 
 /// A mutable builder for [`SaveState`]s.
-pub struct SaveStateBuilder {
+pub(crate) struct SaveStateBuilder {
     state: Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
 }
 
@@ -21,33 +19,6 @@ impl SaveStateBuilder {
         Self {
             state: Mutex::new(HashMap::new()),
         }
-    }
-
-    pub(crate) fn save_resource<T: Clone + Send + Sync + 'static>(&self, resource: Res<T>) {
-        self.state
-	.lock()
-            .insert(TypeId::of::<T>(), Box::new(resource.clone()));
-    }
-
-    pub(crate) fn save_components<T: Component + Clone>(&self, query: Query<(Entity, &T)>) {
-	let iter = query.iter();
-	let (_, max) = iter.size_hint();
-        let (mut components, mut entities) = if let Some(max) = max {
-		(Vec::with_capacity(max), Vec::with_capacity(max))
-	} else {
-		(Vec::new(), Vec::new())
-	};
-        for (entity, component) in iter {
-            entities.push(entity);
-            components.push(component.clone());
-        }
-        self.state.lock().insert(
-            TypeId::of::<ComponentSlab<T>>(),
-            Box::new(ComponentSlab {
-                components,
-                entities,
-            }),
-        );
     }
 
     pub fn build(self) -> SaveState {
@@ -59,66 +30,84 @@ impl SaveStateBuilder {
 #[derive(Clone)]
 pub struct SaveState(Arc<HashMap<TypeId, Box<dyn Any + Send + Sync>>>);
 
-impl SaveState {
-    pub(crate) fn load_resource<T: Clone + Send + Sync + 'static>(&self, mut resource: ResMut<T>) {
-        // HACK: This is REALLY going to screw with any change detection on these types.
-        let saved = self
-            .0
-            .get(&TypeId::of::<T>())
-            .unwrap()
-            .downcast_ref::<T>()
-            .unwrap();
-        *resource = saved.clone();
-    }
-
-    pub(crate) fn load_components<T: Component + Clone>(&self, mut query: Query<&mut T>) {
-        let slab = self
-            .0
-            .get(&TypeId::of::<ComponentSlab<T>>())
-            .unwrap()
-            .downcast_ref::<ComponentSlab<T>>()
-            .unwrap();
-
-        // HACK: This is REALLY going to screw with any change detection on these types.
-        for (entity, component) in slab.entities.iter().zip(slab.components.iter()) {
-            if let Ok(mut comp) = query.get_mut(*entity) {
-                *comp = component.clone();
-            } else {
-                warn!(
-                    "Attempted to load component '{}' from a save state for entity {:?} but the entity no longer exists.",
-                    type_name::<T>(),
-                    entity
-                )
-            }
-        }
-    }
-}
-
 pub(crate) fn save_resource<T: Clone + Send + Sync + 'static>(
     save_state: Res<SaveStateBuilder>,
-    resource: Res<T>,
+    resource: Option<Res<T>>,
 ) {
-    save_state.save_resource(resource);
+    if let Some(resource) = resource {
+        save_state
+            .state
+            .lock()
+            .insert(TypeId::of::<T>(), Box::new(resource.clone()));
+    }
 }
 
 pub(crate) fn load_resource<T: Clone + Send + Sync + 'static>(
     save_state: Res<SaveState>,
-    resource: ResMut<T>,
+    resource: Option<ResMut<T>>,
+    mut commands: Commands,
 ) {
-    save_state.load_resource(resource);
+    // HACK: This is REALLY going to screw with any change detection on these types.
+    let saved = save_state.0.get(&TypeId::of::<T>());
+    match (saved, resource) {
+        (Some(saved), Some(mut resource)) => {
+            let saved = saved.downcast_ref::<T>().unwrap();
+            *resource = saved.clone();
+        }
+        (Some(saved), None) => {
+            let saved = saved.downcast_ref::<T>().unwrap();
+            commands.insert_resource(saved.clone());
+        }
+        (None, Some(_)) => {
+            commands.remove_resource::<T>();
+        }
+        (None, None) => {}
+    }
 }
 
-// This disallows parallelization while saving. Is this design OK?
 pub(crate) fn save_components<T: Component + Clone>(
     save_state: Res<SaveStateBuilder>,
     query: Query<(Entity, &T)>,
 ) {
-    save_state.save_components(query);
+    let components: HashMap<Entity, T> = query
+        .iter()
+        .map(|(entity, component)| (entity, component.clone()))
+        .collect();
+    if !components.is_empty() {
+        save_state.state.lock().insert(
+            TypeId::of::<SavedComponents<T>>(),
+            Box::new(SavedComponents { components }),
+        );
+    }
 }
 
 pub(crate) fn load_components<T: Component + Clone>(
     save_state: Res<SaveState>,
-    query: Query<&mut T>,
+    mut query: Query<(Entity, &mut T)>,
+    mut commands: Commands,
 ) {
-    save_state.load_components(query);
+    let saved = save_state.0.get(&TypeId::of::<SavedComponents<T>>());
+    let slab = if let Some(slab) = saved {
+        slab.downcast_ref::<SavedComponents<T>>().unwrap()
+    } else {
+        for (entity, _) in query.iter() {
+            commands.entity(entity).remove::<T>();
+        }
+        return;
+    };
+
+    let mut components = slab.components.clone();
+    // HACK: This is REALLY going to screw with any change detection on these types.
+    for (entity, mut comp) in query.iter_mut() {
+        if let Some(component) = components.remove(&entity) {
+            *comp = component;
+        } else {
+            commands.entity(entity).remove::<T>();
+        }
+    }
+
+    // Everything else that remains was either removed or had it's entity despawned.
+    for (entity, component) in components {
+        commands.entity(entity).insert(component);
+    }
 }

--- a/bevy_backroll/src/save_state.rs
+++ b/bevy_backroll/src/save_state.rs
@@ -133,7 +133,7 @@ pub(crate) fn load_components<T: Component + Clone>(
 
     // HACK: This is REALLY going to screw with any change detection on these types.
     for (entity, network_id, comp) in query.iter_mut() {
-        match (slab.components.get(&network_id), comp) {
+        match (slab.components.get(network_id), comp) {
             (Some(saved), Some(mut comp)) => {
                 *comp = saved.clone();
             }

--- a/bevy_backroll/src/save_state.rs
+++ b/bevy_backroll/src/save_state.rs
@@ -1,34 +1,45 @@
+use crate::NetworkId;
 use bevy_ecs::prelude::*;
 use parking_lot::Mutex;
 use std::any::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 #[derive(Clone)]
 struct SavedComponents<T: Clone> {
-    components: HashMap<Entity, T>,
+    components: HashMap<NetworkId, T>,
 }
 
 /// A mutable builder for [`SaveState`]s.
 pub(crate) struct SaveStateBuilder {
+    ids: HashSet<NetworkId>,
     state: Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
 }
 
 impl SaveStateBuilder {
     pub fn new() -> Self {
         Self {
+            ids: HashSet::new(),
             state: Mutex::new(HashMap::new()),
         }
     }
 
     pub fn build(self) -> SaveState {
-        SaveState(Arc::new(self.state.into_inner()))
+        SaveState(Arc::new(SaveStateRef {
+            ids: self.ids,
+            state: self.state.into_inner(),
+        }))
     }
+}
+
+struct SaveStateRef {
+    ids: HashSet<NetworkId>,
+    state: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
 }
 
 /// A read only save state of a Bevy world.
 #[derive(Clone)]
-pub struct SaveState(Arc<HashMap<TypeId, Box<dyn Any + Send + Sync>>>);
+pub struct SaveState(Arc<SaveStateRef>);
 
 pub(crate) fn save_resource<T: Clone + Send + Sync + 'static>(
     save_state: Res<SaveStateBuilder>,
@@ -48,7 +59,7 @@ pub(crate) fn load_resource<T: Clone + Send + Sync + 'static>(
     mut commands: Commands,
 ) {
     // HACK: This is REALLY going to screw with any change detection on these types.
-    let saved = save_state.0.get(&TypeId::of::<T>());
+    let saved = save_state.0.state.get(&TypeId::of::<T>());
     match (saved, resource) {
         (Some(saved), Some(mut resource)) => {
             let saved = saved.downcast_ref::<T>().unwrap();
@@ -65,13 +76,17 @@ pub(crate) fn load_resource<T: Clone + Send + Sync + 'static>(
     }
 }
 
+pub(crate) fn save_network_ids(mut save_state: ResMut<SaveStateBuilder>, query: Query<&NetworkId>) {
+    save_state.ids = query.iter().cloned().collect();
+}
+
 pub(crate) fn save_components<T: Component + Clone>(
     save_state: Res<SaveStateBuilder>,
-    query: Query<(Entity, &T)>,
+    query: Query<(&NetworkId, &T)>,
 ) {
-    let components: HashMap<Entity, T> = query
+    let components: HashMap<NetworkId, T> = query
         .iter()
-        .map(|(entity, component)| (entity, component.clone()))
+        .map(|(id, component)| (*id, component.clone()))
         .collect();
     if !components.is_empty() {
         save_state.state.lock().insert(
@@ -81,16 +96,35 @@ pub(crate) fn save_components<T: Component + Clone>(
     }
 }
 
-pub(crate) fn load_components<T: Component + Clone>(
+pub(crate) fn sync_network_ids(
     save_state: Res<SaveState>,
-    mut query: Query<(Entity, &mut T)>,
+    query: Query<(Entity, &NetworkId)>,
     mut commands: Commands,
 ) {
-    let saved = save_state.0.get(&TypeId::of::<SavedComponents<T>>());
+    // Despawn all network identities that shouldn't exist this frame.
+    let mut ids = save_state.0.ids.clone();
+    for (entity, network_id) in query.iter() {
+        if !ids.remove(network_id) {
+            commands.entity(entity).despawn();
+        }
+    }
+
+    // All IDs that remain need to re-spawned.
+    for network_id in ids {
+        commands.spawn_bundle((network_id,));
+    }
+}
+
+pub(crate) fn load_components<T: Component + Clone>(
+    save_state: Res<SaveState>,
+    mut query: Query<(Entity, &NetworkId, Option<&mut T>)>,
+    mut commands: Commands,
+) {
+    let saved = save_state.0.state.get(&TypeId::of::<SavedComponents<T>>());
     let slab = if let Some(slab) = saved {
         slab.downcast_ref::<SavedComponents<T>>().unwrap()
     } else {
-        for (entity, _) in query.iter() {
+        for (entity, _, _) in query.iter() {
             commands.entity(entity).remove::<T>();
         }
         return;
@@ -98,16 +132,18 @@ pub(crate) fn load_components<T: Component + Clone>(
 
     let mut components = slab.components.clone();
     // HACK: This is REALLY going to screw with any change detection on these types.
-    for (entity, mut comp) in query.iter_mut() {
-        if let Some(component) = components.remove(&entity) {
-            *comp = component;
-        } else {
-            commands.entity(entity).remove::<T>();
+    for (entity, network_id, comp) in query.iter_mut() {
+        match (components.remove(&network_id), comp) {
+            (Some(saved), Some(mut comp)) => {
+                *comp = saved;
+            }
+            (Some(saved), None) => {
+                commands.entity(entity).insert(saved);
+            }
+            (None, Some(_)) => {
+                commands.entity(entity).remove::<T>();
+            }
+            (None, None) => {}
         }
-    }
-
-    // Everything else that remains was either removed or had it's entity despawned.
-    for (entity, component) in components {
-        commands.entity(entity).insert(component);
     }
 }

--- a/bevy_backroll/src/steam.rs
+++ b/bevy_backroll/src/steam.rs
@@ -1,5 +1,5 @@
 use backroll_transport_steam::SteamP2PManager;
-use bevy_app::{AppBuilder, Plugin};
+use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 use bevy_steamworks::{Client, ClientManager, SteamworksPlugin};
 use bevy_tasks::IoTaskPool;
@@ -21,7 +21,7 @@ fn initialize_steam_socket(
 pub struct BackrollSteamPlugin;
 
 impl Plugin for BackrollSteamPlugin {
-    fn build(&self, builder: &mut AppBuilder) {
+    fn build(&self, builder: &mut App) {
         builder
             .add_plugin(SteamworksPlugin)
             .add_startup_system(initialize_steam_socket.system());


### PR DESCRIPTION
This PR dramatically improves the ergonomics of bevy_backroll, implementing the following:

 - Removes the need for a user-made config type. `bevy_backroll` provides one now, generic over the input type.
 - Removes most of the user facing generics when setting up the app and systems. No more turbofish in the user-facing code!
 - Implements an automatic saving/loading system for copying Clone-able components and resources into a Backroll save states. This relies on each entity to have a `NetworkId` component that maintains the entity identity across.